### PR TITLE
Partially addressing feature suggestion #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules
 npm-debug.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ If you need to add a comment to a pad:
   Result:
   ![Screen shot](http://i.imgur.com/KM4lPJx.png)
 
+NOTE: Adding a comment to a pad via API will make the other editors with that pad to be alerted, but this feature is only active if your Etherpad is run in `loadTest` mode. Read [the Etherpad Guide](https://github.com/ether/etherpad-lite/wiki/Load-Testing-Etherpad) for how to enable load testing.
+
 ## License
 Apache 2

--- a/README.md
+++ b/README.md
@@ -8,5 +8,26 @@ npm install ep_page_view
 git clone https://github.com/JohnMcLear/ep_comments.git node_modules/ep_comments_page
 ```
 
+## Creating comment via API
+If you need to add a comment to a pad:
+
+* Call this route to create the comment on Etherpad and get the comment id:
+  ```
+  curl "http://localhost:9001/p/THE_PAD_ID/comments?api_key=YOUR_API_KEY&name=AUTHOR&text=COMMENT"
+  ```
+
+  The response will be:
+  ```
+  {"code":0,"commentId":"c-VEtzKolgD5krJOVU"}
+  ```
+
+* Use the returned commentId to set the pad HTML [via API](http://etherpad.org/doc/v1.5.6/#index_sethtml_padid_html):
+  ```
+  My comment goes <span class="comment c-VEtzKolgD5krJOVU">here<span>.
+  ```
+
+  Result:
+  ![Screen shot](http://i.imgur.com/KM4lPJx.png)
+
 ## License
 Apache 2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you need to add a comment to a pad:
 
 * Call this route to create the comment on Etherpad and get the comment id:
   ```
-  curl "http://localhost:9001/p/THE_PAD_ID/comments?api_key=YOUR_API_KEY&name=AUTHOR&text=COMMENT"
+  curl -X POST http://localhost:9001/p/THE_PAD_ID/comments -d "apikey=YOUR_API_KEY" -d "name=AUTHOR" -d "text=COMMENT"
   ```
 
   The response will be:

--- a/commentManager.js
+++ b/commentManager.js
@@ -1,9 +1,20 @@
 var db = require('ep_etherpad-lite/node/db/DB').db;
 var ERR = require("ep_etherpad-lite/node_modules/async-stacktrace");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+var readOnlyManager = require("ep_etherpad-lite/node/db/ReadOnlyManager.js");
 
 exports.getComments = function (padId, callback)
 {
+  // We need to change readOnly PadIds to Normal PadIds
+  var isReadOnly = padId.indexOf("r.") === 0;
+  if(isReadOnly){
+    readOnlyManager.getPadId(padId, function(err, rwPadId){
+      padId = rwPadId;
+    });
+  };
+
+  // Not sure if we will encouter race conditions here..  Be careful.
+
   //get the globalComments
   db.get("comments:" + padId, function(err, comments)
   {
@@ -16,6 +27,14 @@ exports.getComments = function (padId, callback)
 
 exports.addComment = function(padId, data, callback)
 {
+ // We need to change readOnly PadIds to Normal PadIds
+  var isReadOnly = padId.indexOf("r.") === 0;
+  if(isReadOnly){
+    readOnlyManager.getPadId(padId, function(err, rwPadId){
+      padId = rwPadId;
+    });
+  };
+
   //create the new comment
   var commentId = "c-" + randomString(16);
 
@@ -44,8 +63,15 @@ exports.addComment = function(padId, data, callback)
   });
 };
 
-exports.getCommentReplies = function (padId, callback)
-{
+exports.getCommentReplies = function (padId, callback){
+ // We need to change readOnly PadIds to Normal PadIds
+  var isReadOnly = padId.indexOf("r.") === 0;
+  if(isReadOnly){
+    readOnlyManager.getPadId(padId, function(err, rwPadId){
+      padId = rwPadId;
+    });
+  };
+
   //get the globalComments replies
   db.get("comment-replies:" + padId, function(err, replies)
   {
@@ -57,8 +83,15 @@ exports.getCommentReplies = function (padId, callback)
 };
 
 
-exports.addCommentReply = function(padId, data, callback)
-{
+exports.addCommentReply = function(padId, data, callback){
+  // We need to change readOnly PadIds to Normal PadIds
+  var isReadOnly = padId.indexOf("r.") === 0;
+  if(isReadOnly){
+    readOnlyManager.getPadId(padId, function(err, rwPadId){
+      padId = rwPadId;
+    });
+  };
+
   //create the new reply replyid
   var replyId = "c-reply-" + randomString(16);
 

--- a/comments.js
+++ b/comments.js
@@ -21,10 +21,10 @@ exports.getPadComments = function(padID, callback)
 
 exports.addPadComment = function(padID, data, callback)
 {
-  commentManager.addComment(padID, data, function (err, commentID)
+  commentManager.addComment(padID, data, function (err, commentID, comment)
   {
     if(ERR(err, callback)) return;
 
-    if(commentID !== null) callback(null, commentID);
+    if(commentID !== null) callback(null, commentID, comment);
   });
 };

--- a/ep.json
+++ b/ep.json
@@ -11,6 +11,7 @@
       },
       "hooks": {
         "socketio": "ep_comments_page/index",
+        "expressCreateServer": "ep_comments_page/index",
         "eejsBlock_editbarMenuLeft": "ep_comments_page/index",
         "eejsBlock_dd_insert": "ep_comments_page/index",
         "eejsBlock_scripts": "ep_comments_page/index",

--- a/ep.json
+++ b/ep.json
@@ -5,6 +5,7 @@
       "pre": ["ep_etherpad-lite/webaccess"],
       "client_hooks": {
         "postAceInit": "ep_comments_page/static/js/index",
+        "collectContentPre": "ep_comments_page/static/js/shared",
         "aceAttribsToClasses": "ep_comments_page/static/js/index",
         "aceEditorCSS": "ep_comments_page/static/js/index",
         "aceEditEvent": "ep_comments_page/static/js/index"
@@ -12,6 +13,7 @@
       "hooks": {
         "socketio": "ep_comments_page/index",
         "expressCreateServer": "ep_comments_page/index",
+        "collectContentPre": "ep_comments_page/static/js/shared",
         "eejsBlock_editbarMenuLeft": "ep_comments_page/index",
         "eejsBlock_dd_insert": "ep_comments_page/index",
         "eejsBlock_scripts": "ep_comments_page/index",

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var eejs = require('ep_etherpad-lite/node/eejs/');
 var fs = require("fs");
 var formidable = require('formidable');
-// var clientIO = require('socket.io-client');
+var clientIO = require('socket.io-client');
 var commentManager = require('./commentManager');
 var comments = require('./comments');
 var padManager = require("ep_etherpad-lite/node/db/PadManager");
-// var settings = require("ep_etherpad-lite/node/utils/Settings");
+var settings = require("ep_etherpad-lite/node/utils/Settings");
 
 //ensure we have an apikey
 var apikey = "";
@@ -63,15 +63,14 @@ exports.socketio = function (hook_name, args, cb){
       });
     });
 
-    // // comment added via API
-    // socket.on('apiAddComment', function (data, callback) {
-    //   var padId = data.padId;
-    //   var commentId = data.commentId;
-    //   var comment = data.comment;
+    // comment added via API
+    socket.on('apiAddComment', function (data) {
+      var padId = data.padId;
+      var commentId = data.commentId;
+      var comment = data.comment;
 
-    //   socket.broadcast.to(padId).emit('pushAddComment', commentId, comment);
-    //   callback(commentId, comment);
-    // });
+      socket.broadcast.to(padId).emit('pushAddComment', commentId, comment);
+    });
 
   });
 };
@@ -134,7 +133,7 @@ exports.expressCreateServer = function (hook_name, args, callback) {
         if(err) {
           res.json({code: 2, message: "internal error", data: null});
         } else {
-          // broadcastCommentAdded(padIdReceived, commentId, comment);
+          broadcastCommentAdded(padIdReceived, commentId, comment);
           res.json({code: 0, commentId: commentId});
         }
       });
@@ -150,30 +149,30 @@ var checkCommentData = function(fields) {
   return false;
 }
 
-// var broadcastCommentAdded = function(padId, commentId, comment) {
-//   var socket = clientIO.connect(broadcastUrl);
+var broadcastCommentAdded = function(padId, commentId, comment) {
+  var socket = clientIO.connect(broadcastUrl);
 
-//   var data = {
-//     padId: padId,
-//     commentId: commentId,
-//     comment: comment
-//   };
+  var data = {
+    padId: padId,
+    commentId: commentId,
+    comment: comment
+  };
 
-//   socket.emit('apiAddComment', data);
-// }
+  socket.emit('apiAddComment', data);
+}
 
-// var buildBroadcastUrl = function() {
-//   var url = "";
-//   if(settings.ssl) {
-//     url += "https://";
-//   } else {
-//     url += "http://";
-//   }
-//   url += settings.ip + ":" + settings.port + "/comment";
+var buildBroadcastUrl = function() {
+  var url = "";
+  if(settings.ssl) {
+    url += "https://";
+  } else {
+    url += "http://";
+  }
+  url += settings.ip + ":" + settings.port + "/comment";
 
-//   return url;
-// }
-// var broadcastUrl = buildBroadcastUrl();
+  return url;
+}
+var broadcastUrl = buildBroadcastUrl();
 
 /*
 exports.expressCreateServer = function (hook_name, args, cb) {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,30 @@
 var eejs = require('ep_etherpad-lite/node/eejs/');
+var fs = require("fs");
+// var clientIO = require('socket.io-client');
 var commentManager = require('./commentManager');
+var comments = require('./comments');
+var padManager = require("ep_etherpad-lite/node/db/PadManager");
+// var settings = require("ep_etherpad-lite/node/utils/Settings");
+
+//ensure we have an apikey
+var apikey = "";
+try {
+  apikey = fs.readFileSync("./APIKEY.txt","utf8");
+}
+catch(e){
+  console.warn('Could not find APIKEY');
+}
 
 exports.socketio = function (hook_name, args, cb){
   var app = args.app;
   var io = args.io;
   var pushComment;
   var padComment = io;
-  
+
   var commentSocket = io
   .of('/comment')
   .on('connection', function (socket) {
-    
+
     // Join the rooms
     socket.on('getComments', function (data, callback) {
       var padId = data.padId;
@@ -26,7 +40,7 @@ exports.socketio = function (hook_name, args, cb){
         callback(replies);
       });
     });
-    
+
     // On add events
     socket.on('addComment', function (data, callback) {
       var padId = data.padId;
@@ -47,6 +61,16 @@ exports.socketio = function (hook_name, args, cb){
         callback(replyId, reply);
       });
     });
+
+    // // comment added via API
+    // socket.on('apiAddComment', function (data, callback) {
+    //   var padId = data.padId;
+    //   var commentId = data.commentId;
+    //   var comment = data.comment;
+
+    //   socket.broadcast.to(padId).emit('pushAddComment', commentId, comment);
+    //   callback(commentId, comment);
+    // });
 
   });
 };
@@ -76,6 +100,78 @@ exports.eejsBlock_styles = function (hook_name, args, cb) {
   return cb();
 };
 
+exports.expressCreateServer = function (hook_name, args, callback) {
+  args.app.get('/p/:pad/:rev?/comments', function(req, res) {
+    // check the api key
+    apiKeyReceived = req.query.apikey || req.query.api_key;
+    if(apiKeyReceived !== apikey.trim()) {
+      res.statusCode = 401;
+      res.json({code: 4, message: "no or wrong API Key", data: null});
+      return;
+    }
+
+    // check comment data
+    var error = checkCommentData(req);
+    if(error) {
+      res.json({code: 1, message: error, data: null});
+      return;
+    }
+    var data = {
+      author: "empty",
+      name: req.query.name,
+      text: req.query.text
+    };
+
+    // sanitize pad id before continuing
+    var padIdReceived = req.params.pad
+    padManager.sanitizePadId(padIdReceived, function(padId) {
+      padIdReceived = padId;
+    });
+
+    comments.addPadComment(padIdReceived, data, function(err, commentId, comment) {
+      if(err) {
+        res.json({code: 2, message: "internal error", data: null});
+      } else {
+        // broadcastCommentAdded(padIdReceived, commentId, comment);
+        res.json({code: 0, commentId: commentId});
+      }
+    });
+  });
+
+}
+
+var checkCommentData = function(req) {
+  if(typeof req.query.name === 'undefined') return "name is required";
+  if(typeof req.query.text === 'undefined') return "text is required";
+
+  return false;
+}
+
+// var broadcastCommentAdded = function(padId, commentId, comment) {
+//   var socket = clientIO.connect(broadcastUrl);
+
+//   var data = {
+//     padId: padId,
+//     commentId: commentId,
+//     comment: comment
+//   };
+
+//   socket.emit('apiAddComment', data);
+// }
+
+// var buildBroadcastUrl = function() {
+//   var url = "";
+//   if(settings.ssl) {
+//     url += "https://";
+//   } else {
+//     url += "http://";
+//   }
+//   url += settings.ip + ":" + settings.port + "/comment";
+
+//   return url;
+// }
+// var broadcastUrl = buildBroadcastUrl();
+
 /*
 exports.expressCreateServer = function (hook_name, args, cb) {
   var app = args.app;
@@ -92,13 +188,13 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   app.get('/p/:pad/:rev?/add/comment/:name/:text', function(req, res, next) {
     var padId = req.params.pad;
     var revision = req.params.rev ? req.params.rev : null;
-    var data = { 
+    var data = {
       author: "empty",
       selection: "empty",
-      name: req.params.name, 
-      text: req.params.text 
+      name: req.params.name,
+      text: req.params.text
     };
-    
+
     comments.addPadComment(padId, data, revision, function(err, commentId) {
       res.contentType('text/x-json');
       res.send('{ "commentId": "'+ commentId +'" }');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
       "email": "john@mclear.co.uk"
     }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "formidable": "*"
+  },
   "engines": {
     "node": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds comments on sidebar and link it to the text.  Support for Page View, requires ep_page_view",
   "name": "ep_comments_page",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "author": {
     "name": "Nicolas Lescop",
     "email": "limplementeur@gmail.com"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,15 @@
     {
       "name": "John McLear",
       "email": "john@mclear.co.uk"
+    },
+    {
+      "name": "Luiza Pagliari",
+      "email": "lpagliari@gmail.com"
     }
   ],
   "dependencies": {
-    "formidable": "*"
+    "formidable": "*",
+    "socket.io-client": "*"
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds comments on sidebar and link it to the text.  Support for Page View, requires ep_page_view",
   "name": "ep_comments_page",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "author": {
     "name": "Nicolas Lescop",
     "email": "limplementeur@gmail.com"

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -175,6 +175,7 @@
   -o-transition: width 500ms;
   transition: width 500ms;
   height:auto;
+  min-height:100px;
 }
 
 #newComment.hidden{

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -189,21 +189,24 @@ ep_comments.prototype.collectComments = function(callback){
     var commentElm  = container.find('#'+ commentId);
     var comment     = comments[commentId];
 
-    if (comment !== null) {
-      // If comment is not in sidebar insert it
-      if (commentElm.length == 0) {
-        self.insertComment(commentId, comment.data, it);
-        commentElm = container.find('#'+ commentId);
-        $(this).on('click', function(){
-          markerTop = $(this).position().top;
-          commentTop = commentElm.position().top;
-          containerTop = container.css('top');
-          container.css('top', containerTop - (commentTop - markerTop));
-        });
-      }
+console.log("comment", comment, comments);
 
+    if(comment){
+      if (comment !== null) {
+        // If comment is not in sidebar insert it
+        if (commentElm.length == 0) {
+          self.insertComment(commentId, comment.data, it);
+          commentElm = container.find('#'+ commentId);
+          $(this).on('click', function(){
+            markerTop = $(this).position().top;
+            commentTop = commentElm.position().top;
+            containerTop = container.css('top');
+            container.css('top', containerTop - (commentTop - markerTop));
+          });
+        }
+      }
     }
-    
+
     var prevCommentElm = commentElm.prev();
     var commentPos;
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -189,8 +189,6 @@ ep_comments.prototype.collectComments = function(callback){
     var commentElm  = container.find('#'+ commentId);
     var comment     = comments[commentId];
 
-console.log("comment", comment, comments);
-
     if(comment){
       if (comment !== null) {
         // If comment is not in sidebar insert it

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,0 +1,8 @@
+var collectContentPre = function(hook, context){
+  var comment = /(?:^| )(c-[A-Za-z0-9]*)/.exec(context.cls);
+  if(comment && comment[1]){
+    context.cc.doAttrib(context.state, "comment::" + comment[1]);
+  }
+};
+
+exports.collectContentPre = collectContentPre;

--- a/static/tests/backend/specs/api/comments.js
+++ b/static/tests/backend/specs/api/comments.js
@@ -23,43 +23,57 @@ describe('addComment', function(){
   });
 
   it('returns code 1 if name is missing', function(done) {
-    api.get(padEndPointWithMissingName())
+    api.post(commentsEndPoint())
+    .field('apikey', apiKey)
+    .field('text', 'This is a comment')
     .expect(codeToBe1)
     .expect('Content-Type', /json/)
     .expect(200, done)
   });
 
   it('returns code 1 if text is missing', function(done) {
-    api.get(padEndPointWithMissingText())
+    api.post(commentsEndPoint())
+    .field('apikey', apiKey)
+    .field('name', 'John Doe')
     .expect(codeToBe1)
     .expect('Content-Type', /json/)
     .expect(200, done)
   });
 
   it('returns code 4 if API key is missing', function(done) {
-    var missingApiKey = null;
-    api.get(padEndPoint('comments', missingApiKey))
+    api.post(commentsEndPoint())
+    .field('name', 'John Doe')
+    .field('text', 'This is a comment')
     .expect(codeToBe4)
     .expect('Content-Type', /json/)
     .expect(401, done)
   });
 
   it('returns code 4 if API key is wrong', function(done) {
-    api.get(padEndPoint('comments', 'wrongApiKey'))
+    api.post(commentsEndPoint())
+    .field('apikey', 'wrongApiKey')
+    .field('name', 'John Doe')
+    .field('text', 'This is a comment')
     .expect(codeToBe4)
     .expect('Content-Type', /json/)
     .expect(401, done)
   });
 
   it('returns code 0 when comment is successfully added', function(done) {
-    api.get(padEndPointWithAllParams())
+    api.post(commentsEndPoint())
+    .field('apikey', apiKey)
+    .field('name', 'John Doe')
+    .field('text', 'This is a comment')
     .expect(codeToBe0)
     .expect('Content-Type', /json/)
     .expect(200, done)
   });
 
   it('returns comment id when comment is successfully added', function(done) {
-    api.get(padEndPointWithAllParams())
+    api.post(commentsEndPoint())
+    .field('apikey', apiKey)
+    .field('name', 'John Doe')
+    .field('text', 'This is a comment')
     .expect(function(res){
       if(res.body.commentId === undefined) throw new Error("Response should have commentId.")
     })
@@ -75,7 +89,10 @@ describe('addComment', function(){
   //   });
 
   //   // creates comment:
-  //   api.get(padEndPointWithAllParams())
+  //   api.post(commentsEndPoint())
+  //   .field('apikey', apiKey)
+  //   .field('name', 'John Doe')
+  //   .field('text', 'This is a comment')
   //   .expect(function(res){
   //     setTimeout(function() { //give it a second to process the message on the client
   //       // TODO review this, test is not failing ever
@@ -103,19 +120,9 @@ var createPad = function(pad, done) {
   done();
 }
 
-var padEndPoint = function(point, key, pad){
-  key = (typeof key !== 'undefined') ?  key : apiKey;
-  pad = (typeof pad !== 'undefined') ?  pad : padID;
-
-  url = '/p/'+pad+'/'+point
-  if (key != null) url += '?apikey='+key
-
-  return url;
+function commentsEndPoint() {
+  return '/p/'+padID+'/comments'
 }
-
-function padEndPointWithMissingName() { return padEndPoint('comments')+"&text=This is a comment" }
-function padEndPointWithMissingText() { return padEndPoint('comments')+"&name=John Doe" }
-function padEndPointWithAllParams()   { return padEndPoint('comments')+"&name=John Doe&text=This is a comment" }
 
 var codeToBe = function(expectedCode, res) {
   if(res.body.code !== expectedCode){

--- a/static/tests/backend/specs/api/comments.js
+++ b/static/tests/backend/specs/api/comments.js
@@ -3,7 +3,8 @@ var appUrl = 'http://localhost:9001';
 var supertest = require('ep_etherpad-lite/node_modules/supertest'),
            fs = require('fs'),
          path = require('path'),
-           // io = require('socket.io-client')
+           io = require('socket.io-client'),
+      request = require('request'),
           api = supertest(appUrl),
  randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 
@@ -23,7 +24,7 @@ describe('addComment', function(){
   });
 
   it('returns code 1 if name is missing', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('apikey', apiKey)
     .field('text', 'This is a comment')
     .expect(codeToBe1)
@@ -32,7 +33,7 @@ describe('addComment', function(){
   });
 
   it('returns code 1 if text is missing', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('apikey', apiKey)
     .field('name', 'John Doe')
     .expect(codeToBe1)
@@ -41,7 +42,7 @@ describe('addComment', function(){
   });
 
   it('returns code 4 if API key is missing', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('name', 'John Doe')
     .field('text', 'This is a comment')
     .expect(codeToBe4)
@@ -50,7 +51,7 @@ describe('addComment', function(){
   });
 
   it('returns code 4 if API key is wrong', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('apikey', 'wrongApiKey')
     .field('name', 'John Doe')
     .field('text', 'This is a comment')
@@ -60,7 +61,7 @@ describe('addComment', function(){
   });
 
   it('returns code 0 when comment is successfully added', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('apikey', apiKey)
     .field('name', 'John Doe')
     .field('text', 'This is a comment')
@@ -70,7 +71,7 @@ describe('addComment', function(){
   });
 
   it('returns comment id when comment is successfully added', function(done) {
-    api.post(commentsEndPoint())
+    api.post(commentsEndPointFor(padID))
     .field('apikey', apiKey)
     .field('name', 'John Doe')
     .field('text', 'This is a comment')
@@ -79,34 +80,89 @@ describe('addComment', function(){
     })
     .end(done)
   });
+})
 
-  // it('broadcasts comment creation to other clients of same pad', function(done) {
-  //   // listens to the pushAddComment message:
-  //   var messageReceived = false;
-  //   var socket = io.connect(appUrl+"/comment");
-  //   socket.on('pushAddComment', function(data) {
-  //     messageReceived = true;
-  //   });
+describe('addComment broadcast', function(){
+  var messageReceived;
 
-  //   // creates comment:
-  //   api.post(commentsEndPoint())
-  //   .field('apikey', apiKey)
-  //   .field('name', 'John Doe')
-  //   .field('text', 'This is a comment')
-  //   .expect(function(res){
-  //     setTimeout(function() { //give it a second to process the message on the client
-  //       // TODO review this, test is not failing ever
-  //       if(!messageReceived) throw new Error("Message should had been received");
-  //       done();
-  //     }, 1000);
-  //   })
-  //   .end(function(err, res){
-  //     if(err) return done(err);
-  //     done();
-  //   })
-  // });
+  // NOTE: this hook will timeout if you don't run your Etherpad in
+  // loadTest mode. Be sure to adjust your settings.json when running
+  // this test suite
+  beforeEach(function(done){
+    messageReceived = false
 
-  // it('does not broadcast comment creation to clients of different pad');
+    //create a new pad before each test run...
+    padID = randomString(5);
+    createPad(padID, function() {
+      // ... and listens to the broadcast message:
+      var socket = io.connect(appUrl + "/comment");
+      var req = { padId: padID };
+      // needs to get comments to be able to join the padID room, where the messages will be broadcast to:
+      socket.emit('getComments', req, function (res){
+        socket.on('pushAddComment', function(data) {
+          messageReceived = true;
+        });
+
+        done();
+      });
+    });
+  });
+
+  it('broadcasts comment creation to other clients of same pad', function(done) {
+    var url = appUrl + commentsEndPointFor(padID);
+    request.post(url,
+      { form: {
+          'apikey': apiKey,
+          'name': 'John Doe',
+          'text': 'This is a comment',
+      } },
+      function(error, res, body) {
+        if(error) {
+          throw error;
+        }
+        else if(res.statusCode != 200) {
+          throw new Error("Failed on calling API. Status code: " + res.statusCode);
+        }
+        else {
+          setTimeout(function() { //give it a second to process the message on the client
+            if(!messageReceived) throw new Error("Message should had been received");
+            done();
+          }, 1000);
+        }
+      }
+    );
+  });
+
+  it('does not broadcast comment creation to clients of different pad', function(done) {
+    // creates another pad...
+    otherPadId = randomString(5);
+    createPad(otherPadId, function() {
+      // ... and add comment to it:
+      var url = appUrl + commentsEndPointFor(otherPadId);
+      request.post(url,
+        { form: {
+            'apikey': apiKey,
+            'name': 'Another author',
+            'text': 'Comment for the other pad',
+        } },
+        function(error, res, body) {
+          if(error) {
+            throw error;
+          }
+          else if(res.statusCode != 200) {
+            throw new Error("Failed on calling API. Status code: " + res.statusCode);
+          }
+          else {
+            setTimeout(function() { //give it a second to process the message on the client
+              if(messageReceived) throw new Error("Message should had been received only for pad " + padID);
+              done();
+            }, 1000);
+          }
+        }
+      );
+    });
+  });
+
 })
 
 /* ***** helper functions ***** */
@@ -120,8 +176,8 @@ var createPad = function(pad, done) {
   done();
 }
 
-function commentsEndPoint() {
-  return '/p/'+padID+'/comments'
+function commentsEndPointFor(pad) {
+  return '/p/'+pad+'/comments'
 }
 
 var codeToBe = function(expectedCode, res) {

--- a/static/tests/backend/specs/api/comments.js
+++ b/static/tests/backend/specs/api/comments.js
@@ -1,0 +1,128 @@
+var appUrl = 'http://localhost:9001';
+
+var supertest = require('ep_etherpad-lite/node_modules/supertest'),
+           fs = require('fs'),
+         path = require('path'),
+           // io = require('socket.io-client')
+          api = supertest(appUrl),
+ randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+
+var apiVersion = 1;
+var padID;
+
+var etherpad_root = '/../../../../../../ep_etherpad-lite/../..';
+var filePath = path.join(__dirname, etherpad_root + '/APIKEY.txt');
+var apiKey = fs.readFileSync(filePath,  {encoding: 'utf-8'});
+apiKey = apiKey.replace(/\n$/, "");
+
+describe('addComment', function(){
+  //create a new pad before each test run
+  beforeEach(function(done){
+    padID = randomString(5);
+    createPad(padID, done);
+  });
+
+  it('returns code 1 if name is missing', function(done) {
+    api.get(padEndPointWithMissingName())
+    .expect(codeToBe1)
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+
+  it('returns code 1 if text is missing', function(done) {
+    api.get(padEndPointWithMissingText())
+    .expect(codeToBe1)
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+
+  it('returns code 4 if API key is missing', function(done) {
+    var missingApiKey = null;
+    api.get(padEndPoint('comments', missingApiKey))
+    .expect(codeToBe4)
+    .expect('Content-Type', /json/)
+    .expect(401, done)
+  });
+
+  it('returns code 4 if API key is wrong', function(done) {
+    api.get(padEndPoint('comments', 'wrongApiKey'))
+    .expect(codeToBe4)
+    .expect('Content-Type', /json/)
+    .expect(401, done)
+  });
+
+  it('returns code 0 when comment is successfully added', function(done) {
+    api.get(padEndPointWithAllParams())
+    .expect(codeToBe0)
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+
+  it('returns comment id when comment is successfully added', function(done) {
+    api.get(padEndPointWithAllParams())
+    .expect(function(res){
+      if(res.body.commentId === undefined) throw new Error("Response should have commentId.")
+    })
+    .end(done)
+  });
+
+  // it('broadcasts comment creation to other clients of same pad', function(done) {
+  //   // listens to the pushAddComment message:
+  //   var messageReceived = false;
+  //   var socket = io.connect(appUrl+"/comment");
+  //   socket.on('pushAddComment', function(data) {
+  //     messageReceived = true;
+  //   });
+
+  //   // creates comment:
+  //   api.get(padEndPointWithAllParams())
+  //   .expect(function(res){
+  //     setTimeout(function() { //give it a second to process the message on the client
+  //       // TODO review this, test is not failing ever
+  //       if(!messageReceived) throw new Error("Message should had been received");
+  //       done();
+  //     }, 1000);
+  //   })
+  //   .end(function(err, res){
+  //     if(err) return done(err);
+  //     done();
+  //   })
+  // });
+
+  // it('does not broadcast comment creation to clients of different pad');
+})
+
+/* ***** helper functions ***** */
+
+var createPad = function(pad, done) {
+  api.get('/api/'+apiVersion+'/createPad?apikey='+apiKey+"&padID="+pad)
+  .end(function(err, res){
+    if(err || (res.body.code !== 0)) done(new Error("Unable to create new Pad"));
+  })
+
+  done();
+}
+
+var padEndPoint = function(point, key, pad){
+  key = (typeof key !== 'undefined') ?  key : apiKey;
+  pad = (typeof pad !== 'undefined') ?  pad : padID;
+
+  url = '/p/'+pad+'/'+point
+  if (key != null) url += '?apikey='+key
+
+  return url;
+}
+
+function padEndPointWithMissingName() { return padEndPoint('comments')+"&text=This is a comment" }
+function padEndPointWithMissingText() { return padEndPoint('comments')+"&name=John Doe" }
+function padEndPointWithAllParams()   { return padEndPoint('comments')+"&name=John Doe&text=This is a comment" }
+
+var codeToBe = function(expectedCode, res) {
+  if(res.body.code !== expectedCode){
+    throw new Error("Code should be " + expectedCode + ", was " + res.body.code);
+  }
+}
+
+function codeToBe0(res) { codeToBe(0, res) }
+function codeToBe1(res) { codeToBe(1, res) }
+function codeToBe4(res) { codeToBe(4, res) }


### PR DESCRIPTION
I was able to create a GET route to add a comment and enabled comments to be added via API route `setHTML()`, but I couldn't find a way to:

* transform the route into a POST;
* broadcast the comment creation to other clients of the pad.

I left some commented out code with the draft of what I was trying to do to broadcast the message, maybe someone could help me on that.

I'm not sure if this code is enough to be accepted as a pull request for the plugin, but it was what I needed to be able to add comments without using the Etherpad editor on a browser (using only `setHTML()`).