### PR TITLE
Fix hiding of "Accept Change" button for read-only users.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -31,7 +31,9 @@ function ep_comments(context){
 
   // If we're on a read only pad then hide the ability to attempt to merge a suggestion
   if(clientVars.readonly){
-    this.padInner.append("<style>.comment-changeTo-approve{display:none;}</style>");
+    this.padInner.append(
+        "<style>.comment-changeTo-approve," +
+               ".comment-reply-changeTo-approve{display:none;}</style>");
   }
 }
 


### PR DESCRIPTION
The button was being hidden for top-level comments but not replies to comments.