### PR TITLE
Fixing issues on smaller screens (<850px)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+deploy:
+  api_key:
+    secure: crKar9Ul+XEpiPQisz+LR2xLU9QkiV72MvXY2zrNU86qpl2HDqxwEZ9L395+3F4EdQAtmvf7duVMQK0BVmMrXNC5IVPFByUG2rBieX/xX3Vgi2JUZHH9fShf0MysHnCcJPmKY8BHhughvP6ad8UrI+CGqjcWzxgzKzF3gJfogoo=
+  provider: npm
+  email: john@mclear.co.uk
+

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,6 +2,7 @@
   "ep_comments_page.comment" : "Comment",
   "ep_comments_page.comments" : "Comments",
   "ep_comments_page.add_comment.title" : "Add new comment on selection",
+  "ep_comments_page.delete_comment.title" : "Delete this comment",
   "ep_comments_page.show_comments" : "Show Comments",
   "ep_comments_page.comments_template.suggested_change" : "Suggested Change:",
   "ep_comments_page.comments_template.accept_change.value" : "Accept Change",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2,6 +2,7 @@
   "ep_comments_page.comment" : "Comentário",
   "ep_comments_page.comments" : "Comentários",
   "ep_comments_page.add_comment.title" : "Adicionar novo comentário ao texto selecionado",
+  "ep_comments_page.delete_comment.title" : "Apagar este comentário",
   "ep_comments_page.show_comments" : "Mostrar Comentários",
   "ep_comments_page.comments_template.suggested_change" : "Alteração Sugerida:",
   "ep_comments_page.comments_template.accept_change.value" : "Aceitar Sugestão",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds comments on sidebar and link it to the text.  Support for Page View, requires ep_page_view",
   "name": "ep_comments_page",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": {
     "name": "Nicolas Lescop",
     "email": "limplementeur@gmail.com"

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -24,6 +24,11 @@
   cursor:pointer;
   line-height:14px;
   display:block;
+  font-family: "fontawesome-etherpad";
+}
+
+.comment-delete:before{
+  content: "\e82a";
 }
 
 .comment-delete:hover{

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -237,8 +237,8 @@
   width:1050px;
 }
 
-/* dont display comments at < 850px wide */
-@media (max-width: 850px) {
+/* dont display comments at < 955px wide */
+@media (max-width: 955px) {
   #outerdocbody{
     width:100%;
     padding-right:0px;
@@ -248,8 +248,8 @@
   }
 }
 
-/* display comments at > 850px wide */
-@media (min-width: 850px) {
+/* display comments at > 955px wide */
+@media (min-width: 955px) {
   #comments.active{
     display:block;
   }

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -3,6 +3,37 @@
   border-radius: 0px;
 }
 
+.comment-delete-container{
+  margin-left:160px;
+  height: 15px;
+  background-color:#c6c6c6;
+  text-align:center;
+  line-height:14px;
+  color:#666;
+  display:none;
+  -webkit-user-select: none; /* Chrome/Safari */        
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
+
+  /* Rules below not implemented in browsers yet */
+  -o-user-select: none;
+  user-select: none;  
+}
+
+.comment-delete{
+  cursor:pointer;
+  line-height:14px;
+  display:block;
+}
+
+.comment-delete:hover{
+  font-weight:bold;
+}
+
+.sidebar-comment:hover .comment-delete-container{
+  display:block;
+}
+
 .sidebar-comment:hover .comment-text{
   height:auto;
   white-space:normal;
@@ -112,7 +143,7 @@
   overflow: hidden;
   right:0px;
   margin-left: 10px;
-  padding: 3px 5px;
+  padding: 0px 5px 5px 5px;  
   background: white;
   width:90%;
   height:20px;

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -80,6 +80,22 @@
   z-index:1;
 }
 
+#newComments {
+  display:none;
+  width:210px;
+  bottom:0;
+  position:absolute;
+  top:10px;
+  right:0px;
+  font-family: Helvetica, Arial, sans-serif;
+  z-index:1;
+}
+
+#newComments.active {
+  display:block;
+  z-index: 1000;
+}
+
 .comment-reply-button{
   float:right;
   display:none;
@@ -96,7 +112,7 @@
   overflow: hidden;
   right:0px;
   margin-left: 10px;
-  padding: 3px 5px;  
+  padding: 3px 5px;
   background: white;
   width:90%;
   height:20px;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -785,7 +785,7 @@ var hooks = {
 
   // Insert comments classes
   aceAttribsToClasses: function(hook, context){
-    if(context.key == 'comment') return ['comment', context.value];
+    if(context.key == 'comment' && context.value !== "comment-deleted") return ['comment', context.value];
   },
 
   aceEditorCSS: function(){

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -589,17 +589,7 @@ ep_comments.prototype.getCommentData = function (){
 // Delete a pad comment cake
 ep_comments.prototype.deleteComment = function(commentId){
 
-  // CAKE NONE OF THIS IS WORKING, NEED A NEW APPROACH
-
-  // We need to get the REP of a given comment and set the comment attribute to null..
-  // All we know is the commentId so we use that to locate the string in a line
-  var padOuter = $('iframe[name="ace_outer"]').contents();
-  var padInner = padOuter.find('iframe[name="ace_inner"]');
-
-  var comment = padInner.contents().find("."+commentId);
-  console.log(comment);
-  comment.removeClass("comment");
-  var self    = this;
+  alert("deleting");
 
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -274,6 +274,10 @@ ep_comments.prototype.collectComments = function(callback){
     var cls             = $this.attr('class');
     var classCommentId  = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
     var commentId       = (classCommentId) ? classCommentId[1] : null;
+    if(!commentId){
+      // console.log("returning due to no comment id, probably due to a deleted comment");
+      return;
+    }
 
     self.padInner.contents().find("#innerdocbody").addClass("comments");
 
@@ -285,7 +289,6 @@ ep_comments.prototype.collectComments = function(callback){
     var commentId   = classCommentId[1];
     var commentElm  = container.find('#'+ commentId);
     var comment     = comments[commentId];
-
     if(comment){
       if (comment !== null) {
         // If comment is not in sidebar insert it
@@ -304,7 +307,6 @@ ep_comments.prototype.collectComments = function(callback){
         self.localize(commentElm);
       }
     }
-
     var prevCommentElm = commentElm.prev();
     var commentPos;
 
@@ -319,7 +321,6 @@ ep_comments.prototype.collectComments = function(callback){
 
     commentElm.css({ 'top': commentPos });
   });
-
   // now if we apply a class such as mouseover to the editor it will go shitty
   // so what we need to do is add CSS for the specific ID to the document...
   // It's fucked up but that's how we do it..
@@ -354,7 +355,6 @@ ep_comments.prototype.collectComments = function(callback){
     commentElm.removeClass('mouseover');
     $('iframe[name="ace_outer"]').contents().find('.comment-modal').hide();
   });
-
   self.setYofComments();
 };
 
@@ -495,8 +495,10 @@ ep_comments.prototype.setYofComments = function(){
     var y = this.offsetTop;
     y = y-5;
     var commentId = /(?:^| )c-([A-Za-z0-9]*)/.exec(this.className); // classname is the ID of the comment
-    var commentEle = padOuter.find('#c-'+commentId[1]) // find the comment
-    commentEle.css("top", y+"px").show();
+    if(commentId){
+      var commentEle = padOuter.find('#c-'+commentId[1]) // find the comment
+      commentEle.css("top", y+"px").show();
+    }
   });
 
 };
@@ -593,8 +595,16 @@ ep_comments.prototype.deleteComment = function(commentId){
   var selector = "."+commentId;
   var repArr = getRepFromSelector(selector, padInner);
   // rep is an array of reps..  I will need to iterate over each to do something meaningful..
+  var ace = this.ace;
   $.each(repArr, function(index, rep){
-    console.log("I need to set an attribute on ", rep);
+
+    ace.callWithAce(function (ace){
+      ace.ace_performSelectionChange(rep[0],rep[1],true);
+      ace.ace_setAttributeOnSelection('comment', 'comment-deleted');
+      // Note that this is the correct way of doing it, instead of there being
+      // a commentId we now flag it as "comment-deleted"
+    },'deleteCommentedSelection', true);
+   
   });
 }
 
@@ -765,9 +775,11 @@ var hooks = {
     $.each(inlineComments, function(){
       var y = this.offsetTop;
       var commentId = /(?:^| )c-([A-Za-z0-9]*)/.exec(this.className);
-      var commentEle = padOuter.find('#c-'+commentId[1]);
-      y = y-5;
-      commentEle.css("top", y+"px").show();
+      if(commentId){
+        var commentEle = padOuter.find('#c-'+commentId[1]);
+        y = y-5;
+        commentEle.css("top", y+"px").show();
+      }
     });
   },
 
@@ -823,10 +835,10 @@ function getRepFromSelector(selector, container){
     var lineNumber = $(parentDiv).prevAll("div").length;
 
     // We can set beginning of rep Y (lineNumber)
-    rep[0][1] = lineNumber;
+    rep[0][0] = lineNumber;
  
     // We can also update the end rep Y
-    rep[1][1] = lineNumber;
+    rep[1][0] = lineNumber;
 
     // Given the comment span, how many characters are before it?
     
@@ -848,18 +860,18 @@ function getRepFromSelector(selector, container){
     // In the example before the correct number would be 21
     // I guess we could do prevAll each length?
     // If there are no spans before we get 0, simples!
+    // Note that this only works if spans are being used, which imho
+    // Is the correct container however if block elements are registered
+    // It's plausable that attributes are not maintained :(
     var leftOffset = 0;
     $(span).prevAll("span").each(function(){
       var spanOffset = $(this).text().length;
-      leftOffset += spanOffset
+      leftOffset += spanOffset;
     });
-
-    rep[0][0] = leftOffset; // Cake this is left to do
-
-    // THIS IS FAKE AND NEEDS FIXING
+    rep[0][1] = leftOffset;
 
     // All we need to know is span text length and it's left offset in chars
-    rep[1][0] = rep[0][0] + $(span).text().length; // Easy!
+    rep[1][1] = rep[0][1] + $(span).text().length; // Easy!
     repArr.push(rep);
   });
   return repArr;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -12,10 +12,11 @@ var cssFiles = ['ep_comments_page/static/css/comment.css'];
 /************************************************************************/
 // Container
 function ep_comments(context){
-  this.container  = null;
-  this.padOuter   = null;
-  this.padInner   = null;
-  this.ace        = context.ace;
+  this.container           = null;
+  this.padOuter            = null;
+  this.padInner            = null;
+  this.newCommentContainer = null;
+  this.ace                 = context.ace;
 
   // Required for instances running on weird ports
   // This probably needs some work for instances running on root or not on /p/
@@ -44,7 +45,7 @@ ep_comments.prototype.init = function(){
 
   // Init prerequisite
   this.findContainers();
-  this.insertContainer();
+  this.insertContainers();
 
   // Get all comments
   this.getComments(function (comments){
@@ -106,21 +107,19 @@ ep_comments.prototype.init = function(){
 
   // On click comment icon toolbar
   $('.addComment').on('click', function(e){
-    $('iframe[name="ace_outer"]').contents().find('#comments').show();
     $('iframe[name="ace_outer"]').contents().find('#comments').addClass("active");
     e.preventDefault(); // stops focus from being lost
     // If a new comment box doesn't already exist
     // Add a new comment and link it to the selection
     // $('iframe[name="ace_outer"]').contents().find('#sidediv').removeClass('sidedivhidden');
-    if (self.container.find('#newComment').length == 0) self.addComment();
+    if (self.newCommentContainer.find('#newComment').length == 0) self.addComment();
     // console.log("setting focus to .comment-content");
-    $('iframe[name="ace_outer"]').contents().find('#comments').find('#newComment').show();
-    $('iframe[name="ace_outer"]').contents().find('#comments').find('#newComment').addClass("visible").removeClass("hidden");
+    self.showNewCommentForm();
     $('iframe[name="ace_outer"]').contents().find('.comment-content').focus();
   });
 
   // Listen for include suggested change toggle
-  this.container.on("change", '#suggestion-checkbox', function(){
+  this.newCommentContainer.on("change", '#suggestion-checkbox', function(){
     if($(this).is(':checked')){
       $('iframe[name="ace_outer"]').contents().find('.suggestion').show();
     }else{
@@ -179,7 +178,7 @@ ep_comments.prototype.init = function(){
 
     var padCommentContent = padInner.contents().find("."+data.commentId).first();
     newString = newString.replace(/(?:\r\n|\r|\n)/g, '<br />');
-    
+
     // Write the new pad contents
     $(padCommentContent).html(newString);
   });
@@ -207,7 +206,7 @@ ep_comments.prototype.init = function(){
 
   // Enable and handle cookies
   if (padcookie.getPref("comments") === false) {
-    self.container.hide();
+    self.container.removeClass("active");
     $('#options-comments').attr('checked','unchecked');
     $('#options-comments').attr('checked',false);
   }else{
@@ -217,16 +216,16 @@ ep_comments.prototype.init = function(){
   $('#options-comments').on('click', function() {
     if($('#options-comments').is(':checked')) {
       padcookie.setPref("comments", true);
-      self.container.show();
+      self.container.addClass("active");
     } else {
       padcookie.setPref("comments", false);
-      self.container.hide();
+      self.container.removeClass("active");
     }
   });
 
   // Check to see if we should show already..
   if($('#options-comments').is(':checked')){
-    self.container.show();
+    self.container.addClass("active");
   }
 
 };
@@ -238,6 +237,24 @@ ep_comments.prototype.findContainers = function(){
   this.padInner = padOuter.find('iframe[name="ace_inner"]');
   this.outerBody = padOuter.find('#outerdocbody')
 };
+
+ep_comments.prototype.showNewCommentForm = function(){
+  var self = this;
+  this.newCommentContainer.addClass("active");
+  // we need to set a timeout otherwise the animation to show #newComment won't be visible
+  window.setTimeout(function() {
+     self.newCommentContainer.find('#newComment').removeClass("hidden").addClass("visible");
+   }, 0);
+}
+
+ep_comments.prototype.hideNewCommentForm = function(){
+  var self = this;
+  this.newCommentContainer.find('#newComment').removeClass("visible").addClass("hidden");
+  // we need to give some time for the animation of #newComment to finish
+  window.setTimeout(function() {
+     self.newCommentContainer.removeClass("active");
+   }, 500);
+}
 
 // Collect Comments and link text content to the comments div
 ep_comments.prototype.collectComments = function(callback){
@@ -252,9 +269,6 @@ ep_comments.prototype.collectComments = function(callback){
     var classCommentId  = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
     var commentId       = (classCommentId) ? classCommentId[1] : null;
 
-    // make sure comments aer visible on the page
-    // container.show();
-    container.addClass("active");
     self.padInner.contents().find("#innerdocbody").addClass("comments");
 
     if (commentId === null) {
@@ -377,24 +391,30 @@ ep_comments.prototype.highlightComment = function(e){
 }
 
 // Insert comment container in sidebar
-ep_comments.prototype.insertContainer = function(){
+ep_comments.prototype.insertContainers = function(){
+  var target = $('iframe[name="ace_outer"]').contents().find("#outerdocbody");
+
   // Add comments
-  $('iframe[name="ace_outer"]').contents().find("#outerdocbody").prepend('<div id="comments"></div>');
+  target.prepend('<div id="comments"></div>');
   this.container = this.padOuter.find('#comments');
+
+  // Add newComments
+  target.prepend('<div id="newComments"></div>');
+  this.newCommentContainer = this.padOuter.find('#newComments');
 };
 
 // Insert new Comment Form
 ep_comments.prototype.insertNewComment = function(comment, callback){
   var index = 0;
+  var self = this;
 
   this.insertComment("", comment, index, true);
 
-  this.container.find('#newComment #comment-reset').on('click',function(){
-    var form = $(this).parent().parent();
-    $('iframe[name="ace_outer"]').contents().find('#comments').find('#newComment').addClass("hidden").removeClass("visible");
+  this.newCommentContainer.find('#newComment #comment-reset').on('click',function(){
+    self.hideNewCommentForm();
   });
 
-  this.container.find('#newComment').submit(function(){
+  this.newCommentContainer.find('#newComment').submit(function(){
     var form = $(this);
     var text = form.find('.comment-content').val();
     var changeTo = form.find('.comment-suggest-to').val();
@@ -405,7 +425,7 @@ ep_comments.prototype.insertNewComment = function(comment, callback){
     }
     if (text.length != 0) {
       form.remove();
-      $('iframe[name="ace_outer"]').contents().find('#comments').find('#newComment').addClass("hidden").removeClass("visible");
+      self.hideNewCommentForm();
       // console.log("calling back", text, index);
       callback(comment, index);
     }
@@ -423,7 +443,7 @@ ep_comments.prototype.insertNewComment = function(comment, callback){
     var padInner = padOuter.find('iframe[name="ace_inner"]');
     var ele = padInner.contents().find(key);
     var y = ele[0].offsetTop;
-    $('iframe[name="ace_outer"]').contents().find('#comments').contents().find('#newComment').css("top", y+"px").show();
+    self.showNewCommentForm();
     // scroll new comment form to focus
     $('iframe[name="ace_outer"]').contents().find('#outerdocbody').scrollTop(y); // Works in Chrome
     $('iframe[name="ace_outer"]').contents().find('#outerdocbody').parent().scrollTop(y); // Works in Firefox
@@ -434,7 +454,7 @@ ep_comments.prototype.insertNewComment = function(comment, callback){
 ep_comments.prototype.insertComment = function(commentId, comment, index, isNew){
   var template          = (isNew === true) ? 'newCommentTemplate' : 'commentsTemplate';
   var content           = null;
-  var container         = this.container;
+  var container         = (isNew === true) ? this.newCommentContainer : this.container;
   var commentAfterIndex = container.find('.sidebar-comment').eq(index);
 
   comment.commentId = commentId;
@@ -480,7 +500,7 @@ ep_comments.prototype.localize = function(element) {
 };
 
 ep_comments.prototype.localizeNewCommentForm = function() {
-  var newCommentForm = this.container.find('#newComment');
+  var newCommentForm = this.newCommentContainer.find('#newComment');
   if (newCommentForm.length !== 0) this.localize(newCommentForm);
 };
 
@@ -590,7 +610,7 @@ ep_comments.prototype.addComment = function (callback){
 
   _(_.range(firstLine, lastLine + 1)).each(function(lineNumber){
      // rep looks like -- starts at line 2, character 1, ends at line 4 char 1
-     /* 
+     /*
      {
         rep.selStart[2,0],
         rep.selEnd[4,2]
@@ -619,7 +639,7 @@ ep_comments.prototype.addComment = function (callback){
   });
 
   // Set the top of the form
-  $('iframe[name="ace_outer"]').contents().find('#comments').find('#newComment').css("top", $('#editorcontainer').css("top"));
+  self.newCommentContainer.find('#newComment').css("top", $('#editorcontainer').css("top"));
   // TODO This doesn't appear to get the Y right for the input field...
 
   this.insertNewComment(data, function (comment, index){

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -107,7 +107,6 @@ ep_comments.prototype.init = function(){
 
   // On click comment icon toolbar
   $('.addComment').on('click', function(e){
-    $('iframe[name="ace_outer"]').contents().find('#comments').addClass("active");
     e.preventDefault(); // stops focus from being lost
     // If a new comment box doesn't already exist
     // Add a new comment and link it to the selection

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -126,6 +126,13 @@ ep_comments.prototype.init = function(){
     }
   });
 
+  // Listen for events to delete a comment
+  // All this does is remove the comment attr on the selection
+  this.container.on("click", ".comment-delete", function(){
+    var commentId = $(this).parent()[0].id;
+    self.deleteComment(commentId);
+  })
+
   // Listen for include suggested change toggle
   this.container.on("change", '.reply-suggestion-checkbox', function(){
     if($(this).is(':checked')){
@@ -404,6 +411,7 @@ ep_comments.prototype.insertContainers = function(){
 
 // Insert new Comment Form
 ep_comments.prototype.insertNewComment = function(comment, callback){
+  var ace = this.ace;
   var index = 0;
   var self = this;
 
@@ -432,7 +440,6 @@ ep_comments.prototype.insertNewComment = function(comment, callback){
   });
 
   // Set the top of the form to be the same Y as the target Rep
-  var ace = this.ace;
   ace.callWithAce(function (ace){
     var rep = ace.ace_getRep();
     // console.log("rep", rep); // doesn't fire twice
@@ -577,6 +584,23 @@ ep_comments.prototype.getCommentData = function (){
   }
 
   return data;
+}
+
+// Delete a pad comment cake
+ep_comments.prototype.deleteComment = function(commentId){
+
+  // CAKE NONE OF THIS IS WORKING, NEED A NEW APPROACH
+
+  // We need to get the REP of a given comment and set the comment attribute to null..
+  // All we know is the commentId so we use that to locate the string in a line
+  var padOuter = $('iframe[name="ace_outer"]').contents();
+  var padInner = padOuter.find('iframe[name="ace_inner"]');
+
+  var comment = padInner.contents().find("."+commentId);
+  console.log(comment);
+  comment.removeClass("comment");
+  var self    = this;
+
 }
 
 // Add a pad comment
@@ -731,7 +755,6 @@ var hooks = {
   },
 
   aceEditEvent: function(hook, context){
-    // Cake this bit is a bit rough..
     var padOuter = $('iframe[name="ace_outer"]').contents();
     // padOuter.find('#sidediv').removeClass("sidedivhidden"); // TEMPORARY to do removing authorship colors can add sidedivhidden class to sidesiv!
     if(!context.callstack.docTextChanged) return;

--- a/static/tests/frontend/specs/commentDelete.js
+++ b/static/tests/frontend/specs/commentDelete.js
@@ -1,0 +1,84 @@
+describe("Comment Delete", function(){
+  //create a new pad with comment before each test run
+  beforeEach(function(cb){
+    helper.newPad(function() {
+      createComment(function() {
+        // ensure we can delete a comment
+        cb();
+      });
+    });
+    this.timeout(60000);
+  });
+
+  it("Ensures a comment can be deleted", function(done) {
+    deleteComment(function(){
+      var chrome$ = helper.padChrome$;
+      var outer$ = helper.padOuter$;
+      var commentId = getCommentId();
+      expect(chrome$(".sidebar-comment").is(":visible")).to.be(false);
+      done();
+    });
+  });
+
+});
+
+function createComment(callback) {
+  var inner$ = helper.padInner$;
+  var outer$ = helper.padOuter$;
+  var chrome$ = helper.padChrome$;
+
+  // get the first text element out of the inner iframe
+  var $firstTextElement = inner$("div").first();
+
+  // simulate key presses to delete content
+  $firstTextElement.sendkeys('{selectall}'); // select all
+  $firstTextElement.sendkeys('{del}'); // clear the first line
+  $firstTextElement.sendkeys('This content will receive a comment'); // insert text
+
+  // get the comment button and click it
+  $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
+  var $commentButton = chrome$(".addComment");
+  $commentButton.click();
+
+  // fill the comment form and submit it
+  var $commentField = outer$("textarea.comment-content");
+  $commentField.val("My comment");
+  var $hasSuggestion = outer$("#suggestion-checkbox");
+  $hasSuggestion.click();
+  var $suggestionField = outer$("textarea.comment-suggest-to");
+  $suggestionField.val("Change to this suggestion");
+  var $submittButton = outer$("input[type=submit]");
+  $submittButton.click();
+
+  // wait until comment is created and comment id is set
+  helper.waitFor(function() {
+    console.log("HERE");
+    return getCommentId() !== null;
+  })
+  .done(callback);
+}
+
+function deleteComment(callback){
+  var chrome$ = helper.padChrome$;
+  var outer$ = helper.padOuter$;
+
+  //click on the settings button to make settings visible
+  var $deleteButton = outer$(".comment-delete");
+  $deleteButton.click();
+
+  helper.waitFor(function() {
+console.log(chrome$(".sidebar-comment").is(":visible") === false)
+    return chrome$(".sidebar-comment").is(":visible") === false;
+  })
+  .done(callback);
+}
+
+function getCommentId() {
+  var inner$ = helper.padInner$;
+  var comment = inner$(".comment").first();
+  var cls = comment.attr('class');
+  var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+  var commentId = (classCommentId) ? classCommentId[1] : null;
+
+  return commentId;
+}

--- a/static/tests/frontend/specs/comment_l10n.js
+++ b/static/tests/frontend/specs/comment_l10n.js
@@ -65,75 +65,77 @@ describe("Comment Localization", function(){
       done();
     });
   });
+
+  /* ********** Helper functions ********** */
+
+  var createComment = function(callback) {
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var chrome$ = helper.padChrome$;
+
+    // get the first text element out of the inner iframe
+    var $firstTextElement = inner$("div").first();
+
+    // simulate key presses to delete content
+    $firstTextElement.sendkeys('{selectall}'); // select all
+    $firstTextElement.sendkeys('{del}'); // clear the first line
+    $firstTextElement.sendkeys('This content will receive a comment'); // insert text
+
+    // get the comment button and click it
+    $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    // fill the comment form and submit it
+    var $commentField = outer$("textarea.comment-content");
+    $commentField.val("My comment");
+    var $hasSuggestion = outer$("#suggestion-checkbox");
+    $hasSuggestion.click();
+    var $suggestionField = outer$("textarea.comment-suggest-to");
+    $suggestionField.val("Change to this suggestion");
+    var $submittButton = outer$("input[type=submit]");
+    $submittButton.click();
+
+    // wait until comment is created and comment id is set
+    helper.waitFor(function() {
+      return getCommentId() !== null;
+     })
+    .done(callback);
+  }
+
+  var changeEtherpadLanguageTo = function(lang, callback) {
+    var boldTitles = {
+      'en' : 'Bold (Ctrl+B)',
+      'pt-br' : 'Negrito (Ctrl-B)',
+      'de' : 'Fett (Strg-B)'
+    };
+    var chrome$ = helper.padChrome$;
+
+    //click on the settings button to make settings visible
+    var $settingsButton = chrome$(".buttonicon-settings");
+    $settingsButton.click();
+
+    //select the language
+    var $language = chrome$("#languagemenu");
+    $language.val(lang);
+    $language.change();
+
+    // hide settings again
+    $settingsButton.click();
+
+    helper.waitFor(function() {
+      return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
+     })
+    .done(callback);
+  }
+
+  var getCommentId = function() {
+    var inner$ = helper.padInner$;
+    var comment = inner$(".comment").first();
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  }
 });
-
-function createComment(callback) {
-  var inner$ = helper.padInner$;
-  var outer$ = helper.padOuter$;
-  var chrome$ = helper.padChrome$;
-
-  // get the first text element out of the inner iframe
-  var $firstTextElement = inner$("div").first();
-
-  // simulate key presses to delete content
-  $firstTextElement.sendkeys('{selectall}'); // select all
-  $firstTextElement.sendkeys('{del}'); // clear the first line
-  $firstTextElement.sendkeys('This content will receive a comment'); // insert text
-
-  // get the comment button and click it
-  $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
-  var $commentButton = chrome$(".addComment");
-  $commentButton.click();
-
-  // fill the comment form and submit it
-  var $commentField = outer$("textarea.comment-content");
-  $commentField.val("My comment");
-  var $hasSuggestion = outer$("#suggestion-checkbox");
-  $hasSuggestion.click();
-  var $suggestionField = outer$("textarea.comment-suggest-to");
-  $suggestionField.val("Change to this suggestion");
-  var $submittButton = outer$("input[type=submit]");
-  $submittButton.click();
-
-  // wait until comment is created and comment id is set
-  helper.waitFor(function() {
-    return getCommentId() !== null;
-   })
-  .done(callback);
-}
-
-function changeEtherpadLanguageTo(lang, callback) {
-  var boldTitles = {
-    'en' : 'Bold (Ctrl+B)',
-    'pt-br' : 'Negrito (Ctrl-B)',
-    'de' : 'Fett (Strg-B)'
-  };
-  var chrome$ = helper.padChrome$;
-
-  //click on the settings button to make settings visible
-  var $settingsButton = chrome$(".buttonicon-settings");
-  $settingsButton.click();
-
-  //select the language
-  var $language = chrome$("#languagemenu");
-  $language.val(lang);
-  $language.change();
-
-  // hide settings again
-  $settingsButton.click();
-
-  helper.waitFor(function() {
-    return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
-   })
-  .done(callback);
-}
-
-function getCommentId() {
-  var inner$ = helper.padInner$;
-  var comment = inner$(".comment").first();
-  var cls = comment.attr('class');
-  var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
-  var commentId = (classCommentId) ? classCommentId[1] : null;
-
-  return commentId;
-}

--- a/static/tests/frontend/specs/comment_settings.js
+++ b/static/tests/frontend/specs/comment_settings.js
@@ -1,0 +1,106 @@
+describe("Comment settings", function() {
+  describe("when user unchecks 'Show Comments'", function() {
+    // create a new pad and check "Show Comments" checkbox
+    before(function(cb){
+      helper.newPad(function() {
+        chooseToShowComments(false, cb);
+      });
+      this.timeout(60000);
+    });
+
+    it("sidebar comments should not be visible when opening a new pad", function(done) {
+      // force to create a new pad, so validation would be on brand new pads
+      helper.newPad(function() {
+        var outer$ = helper.padOuter$;
+        expect(outer$.find("#comments:visible").length).to.be(0);
+        done();
+      });
+    });
+
+    it("sidebar comments should not be visible when adding a new comment to a new pad", function(done) {
+      // force to create a new pad, so validation would be on brand new pads
+      helper.newPad(function() {
+        createComment(function() {
+          var inner$ = helper.padInner$;
+          var outer$ = helper.padOuter$;
+          var chrome$ = helper.padChrome$;
+
+          // get the first text element out of the inner iframe
+          var $firstTextElement = inner$("div").first();
+          $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
+
+          // get the comment button and click it
+          var $commentButton = chrome$(".addComment");
+          $commentButton.click();
+
+          expect(outer$.find("#comments:visible").length).to.be(0);
+          done();
+        });
+      });
+    });
+  });
+
+  /* ********** Helper functions ********** */
+
+  var chooseToShowComments = function(shouldShowComments, callback) {
+    var chrome$ = helper.padChrome$;
+
+    //click on the settings button to make settings visible
+    var $settingsButton = chrome$(".buttonicon-settings");
+    $settingsButton.click();
+
+    //check "Show Comments"
+    var $showComments = chrome$('#options-comments')
+    if ($showComments.is(':checked') !== shouldShowComments) $showComments.click();
+
+    // hide settings again
+    $settingsButton.click();
+
+    callback();
+  }
+
+  var createComment = function(callback) {
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var chrome$ = helper.padChrome$;
+
+    // get the first text element out of the inner iframe
+    var $firstTextElement = inner$("div").first();
+
+    // simulate key presses to delete content
+    $firstTextElement.sendkeys('{selectall}'); // select all
+    $firstTextElement.sendkeys('{del}'); // clear the first line
+    $firstTextElement.sendkeys('This content will receive a comment'); // insert text
+
+    // get the comment button and click it
+    $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    // fill the comment form and submit it
+    var $commentField = outer$("textarea.comment-content");
+    $commentField.val("My comment");
+    var $hasSuggestion = outer$("#suggestion-checkbox");
+    $hasSuggestion.click();
+    var $suggestionField = outer$("textarea.comment-suggest-to");
+    $suggestionField.val("Change to this suggestion");
+    var $submittButton = outer$("input[type=submit]");
+    $submittButton.click();
+
+    // wait until comment is created and comment id is set
+    helper.waitFor(function() {
+      return getCommentId() !== null;
+     })
+    .done(callback);
+  }
+
+  var getCommentId = function() {
+    var inner$ = helper.padInner$;
+    var comment = inner$(".comment").first();
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  }
+});

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -1,407 +1,411 @@
 var prettyDate;
 
-_.each({'en': 'English', 'de': 'a language not localized yet'}, function(description, lang) {
-  describe("Time Formatting in " + description, function(){
+describe("Time Formatting", function() {
+  _.each({'en': 'English', 'de': 'a language not localized yet'}, function(description, lang) {
+    describe("in " + description, function(){
+      before(function(cb) {
+        loadPrettyDate(function() {
+          changeLanguageTo(lang, cb);
+        });
+        this.timeout(60000);
+      });
+
+      // ensure we go back to English to avoid breaking other tests:
+      after(function(cb){
+        changeLanguageTo('en', cb);
+      });
+
+      it("returns '12 seconds ago' when time is 12 seconds in the past", function(done) {
+        expect(prettyDate(secondsInThePast(12))).to.be('12 seconds ago');
+        done();
+      });
+
+      it("returns '12 seconds from now' when time is 12 seconds in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(12))).to.be('12 seconds from now');
+        done();
+      });
+
+      it("returns '1 minute ago' when time is 75 seconds in the past", function(done) {
+        expect(prettyDate(secondsInThePast(75))).to.be('1 minute ago');
+        done();
+      });
+
+      it("returns '1 minute from now' when time is 75 seconds in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(75))).to.be('1 minute from now');
+        done();
+      });
+
+      it("returns '17 minutes ago' when time is some seconds before 17 minutes in the past", function(done) {
+        expect(prettyDate(secondsInThePast(minutes(17) + 2))).to.be('17 minutes ago');
+        done();
+      });
+
+      it("returns '17 minutes from now' when time is some seconds after 17 minutes in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(minutes(17) + 2))).to.be('17 minutes from now');
+        done();
+      });
+
+      it("returns '1 hour ago' when time is some seconds before 1 hour in the past", function(done) {
+        expect(prettyDate(secondsInThePast(hours(1) + 3))).to.be('1 hour ago');
+        done();
+      });
+
+      it("returns '1 hour from now' when time is some seconds after 1 hour in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(hours(1) + 3))).to.be('1 hour from now');
+        done();
+      });
+
+      it("returns '2 hours ago' when time is some seconds before 2 hours in the past", function(done) {
+        expect(prettyDate(secondsInThePast(hours(2) + 4))).to.be('2 hours ago');
+        done();
+      });
+
+      it("returns '2 hours from now' when time is some seconds after 2 hours in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(hours(2) + 4))).to.be('2 hours from now');
+        done();
+      });
+
+      it("returns 'yesterday' when time is some seconds before 24 hours in the past", function(done) {
+        expect(prettyDate(secondsInThePast(hours(24) + 5))).to.be('yesterday');
+        done();
+      });
+
+      it("returns 'tomorrow' when time is some seconds after 24 hours in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(hours(24) + 5))).to.be('tomorrow');
+        done();
+      });
+
+      it("returns '6 days ago' when time is some seconds before 6 days in the past", function(done) {
+        expect(prettyDate(secondsInThePast(days(6) + 6))).to.be('6 days ago');
+        done();
+      });
+
+      it("returns '6 days from now' when time is some seconds after 6 days in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(days(6) + 6))).to.be('6 days from now');
+        done();
+      });
+
+      it("returns 'last week' when time is some seconds before 7 days in the past", function(done) {
+        expect(prettyDate(secondsInThePast(days(7) + 7))).to.be('last week');
+        done();
+      });
+
+      it("returns 'next week' when time is some seconds after 7 days in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(days(7) + 7))).to.be('next week');
+        done();
+      });
+
+      it("returns '2 weeks ago' when time is some seconds before 2 weeks in the past", function(done) {
+        expect(prettyDate(secondsInThePast(weeks(2) + 8))).to.be('2 weeks ago');
+        done();
+      });
+
+      it("returns '2 weeks from now' when time is some seconds after 2 weeks in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(weeks(2) + 8))).to.be('2 weeks from now');
+        done();
+      });
+
+      it("returns 'last month' when time is some seconds before 4 weeks in the past", function(done) {
+        expect(prettyDate(secondsInThePast(weeks(4) + 9))).to.be('last month');
+        done();
+      });
+
+      it("returns 'next month' when time is some seconds after 4 weeks in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(weeks(4) + 9))).to.be('next month');
+        done();
+      });
+
+      it("returns '9 months ago' when time is some seconds before 9 months in the past", function(done) {
+        expect(prettyDate(secondsInThePast(months(9) + 10))).to.be('9 months ago');
+        done();
+      });
+
+      it("returns '9 months from now' when time is some seconds after 9 months in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(months(9) + 10))).to.be('9 months from now');
+        done();
+      });
+
+      it("returns 'last year' when time is some seconds before 12 months in the past", function(done) {
+        expect(prettyDate(secondsInThePast(months(12) + 11))).to.be('last year');
+        done();
+      });
+
+      it("returns 'next year' when time is some seconds after 12 months in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(months(12) + 11))).to.be('next year');
+        done();
+      });
+
+      it("returns '15 years ago' when time is some seconds before 15 years in the past", function(done) {
+        expect(prettyDate(secondsInThePast(years(15) + 12))).to.be('15 years ago');
+        done();
+      });
+
+      it("returns '15 years from now' when time is some seconds after 15 years in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(years(15) + 12))).to.be('15 years from now');
+        done();
+      });
+
+      it("returns 'last century' when time is some seconds before 100 years in the past", function(done) {
+        expect(prettyDate(secondsInThePast(years(100) + 13))).to.be('last century');
+        done();
+      });
+
+      it("returns 'next century' when time is some seconds after 100 years in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(years(100) + 13))).to.be('next century');
+        done();
+      });
+
+      it("returns '2 centuries ago' when time is some seconds before 2 centuries in the past", function(done) {
+        expect(prettyDate(secondsInThePast(centuries(2) + 14))).to.be('2 centuries ago');
+        done();
+      });
+
+      it("returns '2 centuries from now' when time is some seconds after 2 centuries in the future", function(done) {
+        expect(prettyDate(secondsInTheFuture(centuries(2) + 14))).to.be('2 centuries from now');
+        done();
+      });
+
+    })
+  });
+
+  describe("in Portuguese", function(){
     before(function(cb) {
       loadPrettyDate(function() {
-        changeLanguageTo(lang, cb);
+        changeLanguageTo('pt-br', cb);
       });
       this.timeout(60000);
     });
 
-    // ensure we go back to English to avoid breaking other tests:
-    after(function(cb){
-      changeLanguageTo('en', cb);
-    });
-
-    it("returns '12 seconds ago' when time is 12 seconds in the past", function(done) {
-      expect(prettyDate(secondsInThePast(12))).to.be('12 seconds ago');
+    it("returns '12 segundos atrás' when time is 12 seconds in the past", function(done) {
+      expect(prettyDate(secondsInThePast(12))).to.be('12 segundos atrás');
       done();
     });
 
-    it("returns '12 seconds from now' when time is 12 seconds in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(12))).to.be('12 seconds from now');
+    it("returns 'daqui a 12 segundos' when time is 12 seconds in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(12))).to.be('daqui a 12 segundos');
       done();
     });
 
-    it("returns '1 minute ago' when time is 75 seconds in the past", function(done) {
-      expect(prettyDate(secondsInThePast(75))).to.be('1 minute ago');
+    it("returns '1 minuto atrás' when time is 75 seconds in the past", function(done) {
+      expect(prettyDate(secondsInThePast(75))).to.be('1 minuto atrás');
       done();
     });
 
-    it("returns '1 minute from now' when time is 75 seconds in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(75))).to.be('1 minute from now');
+    it("returns 'daqui a 1 minuto' when time is 75 seconds in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(75))).to.be('daqui a 1 minuto');
       done();
     });
 
-    it("returns '17 minutes ago' when time is some seconds before 17 minutes in the past", function(done) {
-      expect(prettyDate(secondsInThePast(minutes(17) + 2))).to.be('17 minutes ago');
+    it("returns '17 minutos atrás' when time is some seconds before 17 minutes in the past", function(done) {
+      expect(prettyDate(secondsInThePast(minutes(17) + 2))).to.be('17 minutos atrás');
       done();
     });
 
-    it("returns '17 minutes from now' when time is some seconds after 17 minutes in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(minutes(17) + 2))).to.be('17 minutes from now');
+    it("returns 'daqui a 17 minutos' when time is some seconds after 17 minutes in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(minutes(17) + 2))).to.be('daqui a 17 minutos');
       done();
     });
 
-    it("returns '1 hour ago' when time is some seconds before 1 hour in the past", function(done) {
-      expect(prettyDate(secondsInThePast(hours(1) + 3))).to.be('1 hour ago');
+    it("returns '1 hora atrás' when time is some seconds before 1 hour in the past", function(done) {
+      expect(prettyDate(secondsInThePast(hours(1) + 3))).to.be('1 hora atrás');
       done();
     });
 
-    it("returns '1 hour from now' when time is some seconds after 1 hour in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(hours(1) + 3))).to.be('1 hour from now');
+    it("returns 'daqui a 1 hora' when time is some seconds after 1 hour in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(hours(1) + 3))).to.be('daqui a 1 hora');
       done();
     });
 
-    it("returns '2 hours ago' when time is some seconds before 2 hours in the past", function(done) {
-      expect(prettyDate(secondsInThePast(hours(2) + 4))).to.be('2 hours ago');
+    it("returns '2 horas atrás' when time is some seconds before 2 hours in the past", function(done) {
+      expect(prettyDate(secondsInThePast(hours(2) + 4))).to.be('2 horas atrás');
       done();
     });
 
-    it("returns '2 hours from now' when time is some seconds after 2 hours in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(hours(2) + 4))).to.be('2 hours from now');
+    it("returns 'daqui a 2 horas' when time is some seconds after 2 hours in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(hours(2) + 4))).to.be('daqui a 2 horas');
       done();
     });
 
-    it("returns 'yesterday' when time is some seconds before 24 hours in the past", function(done) {
-      expect(prettyDate(secondsInThePast(hours(24) + 5))).to.be('yesterday');
+    it("returns 'ontem' when time is some seconds before 24 hours in the past", function(done) {
+      expect(prettyDate(secondsInThePast(hours(24) + 5))).to.be('ontem');
       done();
     });
 
-    it("returns 'tomorrow' when time is some seconds after 24 hours in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(hours(24) + 5))).to.be('tomorrow');
+    it("returns 'amanhã' when time is some seconds after 24 hours in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(hours(24) + 5))).to.be('amanhã');
       done();
     });
 
-    it("returns '6 days ago' when time is some seconds before 6 days in the past", function(done) {
-      expect(prettyDate(secondsInThePast(days(6) + 6))).to.be('6 days ago');
+    it("returns '6 dias atrás' when time is some seconds before 6 days in the past", function(done) {
+      expect(prettyDate(secondsInThePast(days(6) + 6))).to.be('6 dias atrás');
       done();
     });
 
-    it("returns '6 days from now' when time is some seconds after 6 days in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(days(6) + 6))).to.be('6 days from now');
+    it("returns 'daqui a 6 dias' when time is some seconds after 6 days in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(days(6) + 6))).to.be('daqui a 6 dias');
       done();
     });
 
-    it("returns 'last week' when time is some seconds before 7 days in the past", function(done) {
-      expect(prettyDate(secondsInThePast(days(7) + 7))).to.be('last week');
+    it("returns 'semana passada' when time is some seconds before 7 days in the past", function(done) {
+      expect(prettyDate(secondsInThePast(days(7) + 7))).to.be('semana passada');
       done();
     });
 
-    it("returns 'next week' when time is some seconds after 7 days in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(days(7) + 7))).to.be('next week');
+    it("returns 'próxima semana' when time is some seconds after 7 days in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(days(7) + 7))).to.be('próxima semana');
       done();
     });
 
-    it("returns '2 weeks ago' when time is some seconds before 2 weeks in the past", function(done) {
-      expect(prettyDate(secondsInThePast(weeks(2) + 8))).to.be('2 weeks ago');
+    it("returns '2 semanas atrás' when time is some seconds before 2 weeks in the past", function(done) {
+      expect(prettyDate(secondsInThePast(weeks(2) + 8))).to.be('2 semanas atrás');
       done();
     });
 
-    it("returns '2 weeks from now' when time is some seconds after 2 weeks in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(weeks(2) + 8))).to.be('2 weeks from now');
+    it("returns 'daqui a 2 semanas' when time is some seconds after 2 weeks in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(weeks(2) + 8))).to.be('daqui a 2 semanas');
       done();
     });
 
-    it("returns 'last month' when time is some seconds before 4 weeks in the past", function(done) {
-      expect(prettyDate(secondsInThePast(weeks(4) + 9))).to.be('last month');
+    it("returns 'mês passado' when time is some seconds before 4 weeks in the past", function(done) {
+      expect(prettyDate(secondsInThePast(weeks(4) + 9))).to.be('mês passado');
       done();
     });
 
-    it("returns 'next month' when time is some seconds after 4 weeks in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(weeks(4) + 9))).to.be('next month');
+    it("returns 'próximo mês' when time is some seconds after 4 weeks in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(weeks(4) + 9))).to.be('próximo mês');
       done();
     });
 
-    it("returns '9 months ago' when time is some seconds before 9 months in the past", function(done) {
-      expect(prettyDate(secondsInThePast(months(9) + 10))).to.be('9 months ago');
+    it("returns '9 meses atrás' when time is some seconds before 9 months in the past", function(done) {
+      expect(prettyDate(secondsInThePast(months(9) + 10))).to.be('9 meses atrás');
       done();
     });
 
-    it("returns '9 months from now' when time is some seconds after 9 months in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(months(9) + 10))).to.be('9 months from now');
+    it("returns 'daqui a 9 meses' when time is some seconds after 9 months in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(months(9) + 10))).to.be('daqui a 9 meses');
       done();
     });
 
-    it("returns 'last year' when time is some seconds before 12 months in the past", function(done) {
-      expect(prettyDate(secondsInThePast(months(12) + 11))).to.be('last year');
+    it("returns 'ano passado' when time is some seconds before 12 months in the past", function(done) {
+      expect(prettyDate(secondsInThePast(months(12) + 11))).to.be('ano passado');
       done();
     });
 
-    it("returns 'next year' when time is some seconds after 12 months in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(months(12) + 11))).to.be('next year');
+    it("returns 'próximo ano' when time is some seconds after 12 months in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(months(12) + 11))).to.be('próximo ano');
       done();
     });
 
-    it("returns '15 years ago' when time is some seconds before 15 years in the past", function(done) {
-      expect(prettyDate(secondsInThePast(years(15) + 12))).to.be('15 years ago');
+    it("returns '15 anos atrás' when time is some seconds before 15 years in the past", function(done) {
+      expect(prettyDate(secondsInThePast(years(15) + 12))).to.be('15 anos atrás');
       done();
     });
 
-    it("returns '15 years from now' when time is some seconds after 15 years in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(years(15) + 12))).to.be('15 years from now');
+    it("returns 'daqui a 15 anos' when time is some seconds after 15 years in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(years(15) + 12))).to.be('daqui a 15 anos');
       done();
     });
 
-    it("returns 'last century' when time is some seconds before 100 years in the past", function(done) {
-      expect(prettyDate(secondsInThePast(years(100) + 13))).to.be('last century');
+    it("returns 'século passado' when time is some seconds before 100 years in the past", function(done) {
+      expect(prettyDate(secondsInThePast(years(100) + 13))).to.be('século passado');
       done();
     });
 
-    it("returns 'next century' when time is some seconds after 100 years in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(years(100) + 13))).to.be('next century');
+    it("returns 'próximo século' when time is some seconds after 100 years in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(years(100) + 13))).to.be('próximo século');
       done();
     });
 
-    it("returns '2 centuries ago' when time is some seconds before 2 centuries in the past", function(done) {
-      expect(prettyDate(secondsInThePast(centuries(2) + 14))).to.be('2 centuries ago');
+    it("returns '2 séculos atrás' when time is some seconds before 2 centuries in the past", function(done) {
+      expect(prettyDate(secondsInThePast(centuries(2) + 14))).to.be('2 séculos atrás');
       done();
     });
 
-    it("returns '2 centuries from now' when time is some seconds after 2 centuries in the future", function(done) {
-      expect(prettyDate(secondsInTheFuture(centuries(2) + 14))).to.be('2 centuries from now');
+    it("returns 'daqui a 2 séculos' when time is some seconds after 2 centuries in the future", function(done) {
+      expect(prettyDate(secondsInTheFuture(centuries(2) + 14))).to.be('daqui a 2 séculos');
       done();
     });
 
-  })
-})
+  });
 
-describe("Time Formatting in Portuguese", function(){
-  before(function(cb) {
-    loadPrettyDate(function() {
-      changeLanguageTo('pt-br', cb);
+  /* ********** Helper functions ********** */
+
+  var secondsInThePast = function(seconds) {
+    return Date.now() - seconds * 1000;
+  }
+
+  var secondsInTheFuture = function(seconds) {
+    return Date.now() + seconds * 1000;
+  }
+
+  var minutes = function(count) {
+    return 60 * count;
+  }
+
+  var hours = function(count) {
+    return 60 * minutes(count);
+  }
+
+  var days = function(count) {
+    return 24 * hours(count);
+  }
+
+  var weeks = function(count) {
+    return 7 * days(count);
+  }
+
+  var months = function(count) {
+    return 4 * weeks(count);
+  }
+
+  var years = function(count) {
+    return 12 * months(count);
+  }
+
+  var centuries = function(count) {
+    return 100 * years(count);
+  }
+
+  var loadPrettyDate = function(done) {
+    helper.newPad(function() {
+      var chrome$ = helper.padChrome$;
+
+      chrome$.getScript('/static/plugins/ep_comments_page/static/js/timeFormat.js')
+      .done(function(code){
+        chrome$.window.eval(code);
+        prettyDate = chrome$.window.prettyDate;
+
+        done();
+      })
+      .fail(function(jqxhr, settings, exception) {
+        done(exception);
+      });
     });
-    this.timeout(60000);
-  });
+  }
 
-  it("returns '12 segundos atrás' when time is 12 seconds in the past", function(done) {
-    expect(prettyDate(secondsInThePast(12))).to.be('12 segundos atrás');
-    done();
-  });
-
-  it("returns 'daqui a 12 segundos' when time is 12 seconds in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(12))).to.be('daqui a 12 segundos');
-    done();
-  });
-
-  it("returns '1 minuto atrás' when time is 75 seconds in the past", function(done) {
-    expect(prettyDate(secondsInThePast(75))).to.be('1 minuto atrás');
-    done();
-  });
-
-  it("returns 'daqui a 1 minuto' when time is 75 seconds in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(75))).to.be('daqui a 1 minuto');
-    done();
-  });
-
-  it("returns '17 minutos atrás' when time is some seconds before 17 minutes in the past", function(done) {
-    expect(prettyDate(secondsInThePast(minutes(17) + 2))).to.be('17 minutos atrás');
-    done();
-  });
-
-  it("returns 'daqui a 17 minutos' when time is some seconds after 17 minutes in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(minutes(17) + 2))).to.be('daqui a 17 minutos');
-    done();
-  });
-
-  it("returns '1 hora atrás' when time is some seconds before 1 hour in the past", function(done) {
-    expect(prettyDate(secondsInThePast(hours(1) + 3))).to.be('1 hora atrás');
-    done();
-  });
-
-  it("returns 'daqui a 1 hora' when time is some seconds after 1 hour in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(hours(1) + 3))).to.be('daqui a 1 hora');
-    done();
-  });
-
-  it("returns '2 horas atrás' when time is some seconds before 2 hours in the past", function(done) {
-    expect(prettyDate(secondsInThePast(hours(2) + 4))).to.be('2 horas atrás');
-    done();
-  });
-
-  it("returns 'daqui a 2 horas' when time is some seconds after 2 hours in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(hours(2) + 4))).to.be('daqui a 2 horas');
-    done();
-  });
-
-  it("returns 'ontem' when time is some seconds before 24 hours in the past", function(done) {
-    expect(prettyDate(secondsInThePast(hours(24) + 5))).to.be('ontem');
-    done();
-  });
-
-  it("returns 'amanhã' when time is some seconds after 24 hours in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(hours(24) + 5))).to.be('amanhã');
-    done();
-  });
-
-  it("returns '6 dias atrás' when time is some seconds before 6 days in the past", function(done) {
-    expect(prettyDate(secondsInThePast(days(6) + 6))).to.be('6 dias atrás');
-    done();
-  });
-
-  it("returns 'daqui a 6 dias' when time is some seconds after 6 days in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(days(6) + 6))).to.be('daqui a 6 dias');
-    done();
-  });
-
-  it("returns 'semana passada' when time is some seconds before 7 days in the past", function(done) {
-    expect(prettyDate(secondsInThePast(days(7) + 7))).to.be('semana passada');
-    done();
-  });
-
-  it("returns 'próxima semana' when time is some seconds after 7 days in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(days(7) + 7))).to.be('próxima semana');
-    done();
-  });
-
-  it("returns '2 semanas atrás' when time is some seconds before 2 weeks in the past", function(done) {
-    expect(prettyDate(secondsInThePast(weeks(2) + 8))).to.be('2 semanas atrás');
-    done();
-  });
-
-  it("returns 'daqui a 2 semanas' when time is some seconds after 2 weeks in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(weeks(2) + 8))).to.be('daqui a 2 semanas');
-    done();
-  });
-
-  it("returns 'mês passado' when time is some seconds before 4 weeks in the past", function(done) {
-    expect(prettyDate(secondsInThePast(weeks(4) + 9))).to.be('mês passado');
-    done();
-  });
-
-  it("returns 'próximo mês' when time is some seconds after 4 weeks in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(weeks(4) + 9))).to.be('próximo mês');
-    done();
-  });
-
-  it("returns '9 meses atrás' when time is some seconds before 9 months in the past", function(done) {
-    expect(prettyDate(secondsInThePast(months(9) + 10))).to.be('9 meses atrás');
-    done();
-  });
-
-  it("returns 'daqui a 9 meses' when time is some seconds after 9 months in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(months(9) + 10))).to.be('daqui a 9 meses');
-    done();
-  });
-
-  it("returns 'ano passado' when time is some seconds before 12 months in the past", function(done) {
-    expect(prettyDate(secondsInThePast(months(12) + 11))).to.be('ano passado');
-    done();
-  });
-
-  it("returns 'próximo ano' when time is some seconds after 12 months in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(months(12) + 11))).to.be('próximo ano');
-    done();
-  });
-
-  it("returns '15 anos atrás' when time is some seconds before 15 years in the past", function(done) {
-    expect(prettyDate(secondsInThePast(years(15) + 12))).to.be('15 anos atrás');
-    done();
-  });
-
-  it("returns 'daqui a 15 anos' when time is some seconds after 15 years in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(years(15) + 12))).to.be('daqui a 15 anos');
-    done();
-  });
-
-  it("returns 'século passado' when time is some seconds before 100 years in the past", function(done) {
-    expect(prettyDate(secondsInThePast(years(100) + 13))).to.be('século passado');
-    done();
-  });
-
-  it("returns 'próximo século' when time is some seconds after 100 years in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(years(100) + 13))).to.be('próximo século');
-    done();
-  });
-
-  it("returns '2 séculos atrás' when time is some seconds before 2 centuries in the past", function(done) {
-    expect(prettyDate(secondsInThePast(centuries(2) + 14))).to.be('2 séculos atrás');
-    done();
-  });
-
-  it("returns 'daqui a 2 séculos' when time is some seconds after 2 centuries in the future", function(done) {
-    expect(prettyDate(secondsInTheFuture(centuries(2) + 14))).to.be('daqui a 2 séculos');
-    done();
-  });
-
-})
-
-function secondsInThePast(seconds) {
-  return Date.now() - seconds * 1000;
-}
-
-function secondsInTheFuture(seconds) {
-  return Date.now() + seconds * 1000;
-}
-
-function minutes(count) {
-  return 60 * count;
-}
-
-function hours(count) {
-  return 60 * minutes(count);
-}
-
-function days(count) {
-  return 24 * hours(count);
-}
-
-function weeks(count) {
-  return 7 * days(count);
-}
-
-function months(count) {
-  return 4 * weeks(count);
-}
-
-function years(count) {
-  return 12 * months(count);
-}
-
-function centuries(count) {
-  return 100 * years(count);
-}
-
-function loadPrettyDate(done) {
-  helper.newPad(function() {
+  var changeLanguageTo = function(lang, callback) {
+    var boldTitles = {
+      'en' : 'Bold (Ctrl+B)',
+      'pt-br' : 'Negrito (Ctrl-B)',
+      'de' : 'Fett (Strg-B)'
+    };
     var chrome$ = helper.padChrome$;
 
-    chrome$.getScript('/static/plugins/ep_comments_page/static/js/timeFormat.js')
-    .done(function(code){
-      chrome$.window.eval(code);
-      prettyDate = chrome$.window.prettyDate;
+    //click on the settings button to make settings visible
+    var $settingsButton = chrome$(".buttonicon-settings");
+    $settingsButton.click();
 
-      done();
-    })
-    .fail(function(jqxhr, settings, exception) {
-      done(exception);
-    });
-  });
-}
+    //select the language
+    var $language = chrome$("#languagemenu");
+    $language.val(lang);
+    $language.change();
 
-function changeLanguageTo(lang, callback) {
-  var boldTitles = {
-    'en' : 'Bold (Ctrl+B)',
-    'pt-br' : 'Negrito (Ctrl-B)',
-    'de' : 'Fett (Strg-B)'
-  };
-  var chrome$ = helper.padChrome$;
+    // hide settings again
+    $settingsButton.click();
 
-  //click on the settings button to make settings visible
-  var $settingsButton = chrome$(".buttonicon-settings");
-  $settingsButton.click();
-
-  //select the language
-  var $language = chrome$("#languagemenu");
-  $language.val(lang);
-  $language.change();
-
-  // hide settings again
-  $settingsButton.click();
-
-  helper.waitFor(function() {
-    return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
-   })
-  .done(callback);
-}
+    helper.waitFor(function() {
+      return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
+     })
+    .done(callback);
+  }
+});

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -1,6 +1,9 @@
 <script src="../static/plugins/ep_comments_page/static/js/jquery.tmpl.min.js"></script>
 <script id="commentsTemplate" type="text/html">
     <div id="${commentId}" class="sidebar-comment" title="${date}">
+        <p class="comment-delete-container">
+          <span class="comment-delete" title="Delete this comment">x</span>
+        </p>
         <p class="comment-author-name">${name}:</p>
         <p class="comment-text">${text}</p>
         {{if changeTo}}

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -2,7 +2,7 @@
 <script id="commentsTemplate" type="text/html">
     <div id="${commentId}" class="sidebar-comment" title="${date}">
         <p class="comment-delete-container">
-          <span class="comment-delete" title="Delete this comment">x</span>
+          <span class="comment-delete" title="Delete this comment"></span>
         </p>
         <p class="comment-author-name">${name}:</p>
         <p class="comment-text">${text}</p>

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -2,7 +2,7 @@
 <script id="commentsTemplate" type="text/html">
     <div id="${commentId}" class="sidebar-comment" title="${date}">
         <p class="comment-delete-container">
-          <span class="comment-delete" title="Delete this comment"></span>
+          <span class="comment-delete" title="Delete this comment" data-l10n-id="ep_comments_page.delete_comment.title"></span>
         </p>
         <p class="comment-author-name">${name}:</p>
         <p class="comment-text">${text}</p>


### PR DESCRIPTION
While testing ep_comments_page on smaller screens (<850px), I found some issues:

* If user unchecks "Show Comments" setting and clicks button to add a new comment, sidebar comments will be displayed (this also happens on larger screens);
* Sidebar comments were not being hidden on smaller screens if user checks "Show Comments" (i.e. media queries were being ignored). That could be the expected behavior (user can "force" comments to be displayed), but in this case it would not make sense to have the media queries anyway, so I thought this was an issue;

Solution included:

* moving `#newComment` out of `#comments` (and into a similar container), otherwise there would be no way (or I could not think of any) to show the #newComment form while hiding existing sidebar comments;
* replacing existing calls to `show()` by `addClass('active').removeClass('inactive')`, so media queries are useful again;
* removing code from `collectComments()` that made `#comments` always visible because we need to respect user's setting defined on "Show Comments", and this code was ignoring that;

BTW, I think 850px might be too small to limit the media query. It seems that 935px would be better, as it would make sure comments are not overlapping any text on the pad. I didn't change this specific value, but I can do it if you agree that would be better.

![image](https://cloud.githubusercontent.com/assets/836386/7971282/f28f48da-0a19-11e5-999c-ae383edd734d.png)
