### PR TITLE
Display comments as icons on right margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ cd node_modules/ep_comments_page
 npm install
 ```
 
+## Alternative comment display
+The plugin also provides an alternative way to display comments. Instead of having all comments visible on the right of the page, you can have just an icon on the right margin of the page. Comment details are displayed when user clicks on the comment icon:
+
+![Screen shot](http://i.imgur.com/cEo7PdL.png)
+
+To use this way of displaying comments, add the following to your `settings.json`:
+```
+// Display comments as icons, not boxes
+"ep_comments_page": {
+  "displayCommentAsIcon": true,
+},
+```
+
 ## Creating comment via API
 If you need to add a comment to a pad:
 

--- a/ep.json
+++ b/ep.json
@@ -20,6 +20,7 @@
         "eejsBlock_scripts": "ep_comments_page/index",
         "eejsBlock_mySettings": "ep_comments_page/index",
         "eejsBlock_styles": "ep_comments_page/index",
+        "clientVars": "ep_comments_page/index",
         "handleMessageSecurity": "ep_comments_page/index"
       }
     }

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
 
 exports.eejsBlock_scripts = function (hook_name, args, cb) {
   args.content = args.content + eejs.require("ep_comments_page/templates/comments.html", {}, module);
+  args.content = args.content + eejs.require("ep_comments_page/templates/commentIcons.html", {}, module);
   return cb();
 };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var eejs = require('ep_etherpad-lite/node/eejs/');
+var settings = require('ep_etherpad-lite/node/utils/Settings');
 var formidable = require('formidable');
 var clientIO = require('socket.io-client');
 var commentManager = require('./commentManager');
@@ -116,6 +117,11 @@ exports.eejsBlock_scripts = function (hook_name, args, cb) {
 exports.eejsBlock_styles = function (hook_name, args, cb) {
   args.content = args.content + eejs.require("ep_comments_page/templates/styles.html", {}, module);
   return cb();
+};
+
+exports.clientVars = function (hook, context, cb) {
+  var displayCommentAsIcon = settings.ep_comments_page ? settings.ep_comments_page.displayCommentAsIcon : false;
+  return cb({ "displayCommentAsIcon": displayCommentAsIcon });
 };
 
 exports.expressCreateServer = function (hook_name, args, callback) {

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -11,13 +11,13 @@
   line-height:14px;
   color:#666;
   display:none;
-  -webkit-user-select: none; /* Chrome/Safari */        
+  -webkit-user-select: none; /* Chrome/Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+ */
 
   /* Rules below not implemented in browsers yet */
   -o-user-select: none;
-  user-select: none;  
+  user-select: none;
 }
 
 .comment-delete{
@@ -36,6 +36,10 @@
 }
 
 .sidebar-comment:hover .comment-delete-container{
+  display:block;
+}
+
+.sidebar-comment.mouseover .comment-delete-container{
   display:block;
 }
 
@@ -148,7 +152,7 @@
   overflow: hidden;
   right:0px;
   margin-left: 10px;
-  padding: 0px 5px 5px 5px;  
+  padding: 0px 5px 5px 5px;
   background: white;
   width:90%;
   height:20px;

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -35,15 +35,13 @@
   font-weight:bold;
 }
 
-.sidebar-comment:hover .comment-delete-container{
-  display:block;
-}
-
+.sidebar-comment:hover .comment-delete-container,
 .sidebar-comment.mouseover .comment-delete-container{
   display:block;
 }
 
-.sidebar-comment:hover .comment-text{
+.sidebar-comment:hover .comment-text,
+.sidebar-comment.mouseover .comment-text{
   height:auto;
   white-space:normal;
   text-overflow:auto;
@@ -53,13 +51,15 @@
   line-height:24px;
 }
 
-.sidebar-comment:hover{
+.sidebar-comment:hover,
+.sidebar-comment.mouseover{
   height:auto;
   white-space:normal;
   text-overflow:auto;
 }
 
-.sidebar-comment:hover .comment-reply-button {
+.sidebar-comment:hover .comment-reply-button,
+.sidebar-comment.mouseover .comment-reply-button {
   display:block;
 }
 
@@ -169,7 +169,8 @@
   padding:2px;
 }
 
-.sidebar-comment:hover{
+.sidebar-comment:hover,
+.sidebar-comment.mouseover{
   z-index:999;
 }
 

--- a/static/css/commentIcon.css
+++ b/static/css/commentIcon.css
@@ -1,8 +1,13 @@
 #commentIcons {
-  position: relative;
   display: block;
   z-index: 1;
-  left: 760px;
+  margin-left: 760px;
+  padding-left: 25px;
+}
+
+/* when line numbers are not visible, we need to move icons to the left */
+#sidediv.sidedivhidden ~ #commentIcons {
+  padding-left: 0px;
 }
 
 .comment-icon-line {

--- a/static/css/commentIcon.css
+++ b/static/css/commentIcon.css
@@ -1,0 +1,34 @@
+#commentIcons {
+  position: relative;
+  display: block;
+  z-index: 1;
+  left: 760px;
+}
+
+.comment-icon-line {
+  position: absolute;
+}
+.comment-icon {
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: 16px;
+  vertical-align: middle;
+  width: 16px;
+  margin-right: 5px;
+}
+.comment-icon:before {
+  font-family: "fontawesome-etherpad";
+  content: "\e829";
+  color:#666;
+  font-size:14px;
+  padding-top:2px;
+  line-height:17px;
+}
+
+.comment-icon.with-reply:before {
+  content: "\e828";
+}
+
+.comment-icon.active:before {
+  color:orange;
+}

--- a/static/css/commentIcon.css
+++ b/static/css/commentIcon.css
@@ -23,7 +23,7 @@
 }
 .comment-icon:before {
   font-family: "fontawesome-etherpad";
-  content: "\e829";
+  content: "\e838";
   color:#666;
   font-size:14px;
   padding-top:2px;

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -67,9 +67,17 @@ var adjustTopOf = function(commentId, baseTop) {
   return commentElement;
 }
 
+// Indicates if comment is on the expected position (baseTop-5)
+var isOnTop = function(commentId, baseTop) {
+  var commentElement = getPadOuter().find('#'+commentId);
+  var expectedTop = (baseTop - 5) + "px";
+  return commentElement.css("top") === expectedTop;
+}
+
 exports.showComment = showComment;
 exports.hideComment = hideComment;
 exports.hideOpenedComments = hideOpenedComments;
 exports.hideAllComments = hideAllComments;
 exports.highlightComment = highlightComment;
 exports.adjustTopOf = adjustTopOf;
+exports.isOnTop = isOnTop;

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -1,0 +1,75 @@
+// Easier access to outter pad
+var padOuter;
+var getPadOuter = function() {
+  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
+  return padOuter;
+}
+
+var getCommentsContainer = function() {
+  return getPadOuter().find("#comments");
+}
+
+/* ***** Public methods: ***** */
+
+var showComment = function(commentId, e) {
+  var commentElm = getCommentsContainer().find('#'+ commentId);
+  commentElm.show();
+
+  highlightComment(commentId, e);
+};
+
+var hideComment = function(commentId, hideCommentTitle) {
+  var commentElm = getCommentsContainer().find('#'+ commentId);
+  commentElm.removeClass('mouseover');
+
+  // hide even the comment title
+  if (hideCommentTitle) commentElm.hide();
+
+  getPadOuter().contents().find('.comment-modal').hide();
+};
+
+var hideOpenedComments = function() {
+  var openedComments = getCommentsContainer().find('.mouseover');
+  openedComments.removeClass('mouseover').hide();
+
+  getPadOuter().contents().find('.comment-modal').hide();
+}
+
+var hideAllComments = function() {
+  getCommentsContainer().children().hide();
+}
+
+var highlightComment = function(commentId, e){
+  var container       = getCommentsContainer();
+  var commentElm      = container.find('#'+ commentId);
+  var commentsVisible = container.is(":visible");
+  if(commentsVisible) {
+    // sidebar view highlight
+    commentElm.addClass('mouseover');
+  } else {
+    var commentElm = container.find('#'+ commentId);
+    getPadOuter().contents().find('.comment-modal').show().css({
+      left: e.clientX +"px",
+      top: e.clientY + 25 +"px"
+    });
+    // hovering comment view
+    getPadOuter().contents().find('.comment-modal-comment').html(commentElm.html());
+  }
+}
+
+// Adjust position of the comment detail on the container, to be on the same
+// height of the pad text associated to the comment, and return the affected element
+var adjustTopOf = function(commentId, baseTop) {
+  var commentElement = getPadOuter().find('#'+commentId);
+  var targetTop = baseTop - 5;
+  commentElement.css("top", targetTop+"px");
+
+  return commentElement;
+}
+
+exports.showComment = showComment;
+exports.hideComment = hideComment;
+exports.hideOpenedComments = hideOpenedComments;
+exports.hideAllComments = hideAllComments;
+exports.highlightComment = highlightComment;
+exports.adjustTopOf = adjustTopOf;

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -2,18 +2,18 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var commentBoxes = require('ep_comments_page/static/js/commentBoxes');
 
-// Criteria to display (or not) comment as icons
+// Indicates if Etherpad is configured to display icons
 var displayIcons = function() {
-  var shouldDisplayIcons = false;
-  if (clientVars.displayCommentAsIcon) {
-    // we will only display icons if right margin has some space
-    var firstElementOnPad      = getPadInner().contents().find("#innerdocbody > div").first();
-    var rightMargin            = firstElementOnPad.css("margin-right");
-    var hasSpaceToDisplayIcons = rightMargin !== "0px";
-    shouldDisplayIcons         = hasSpaceToDisplayIcons;
-  }
+  return clientVars.displayCommentAsIcon
+}
 
-  return shouldDisplayIcons;
+// Indicates if screen has enough space on right margin to display icons
+var screenHasSpaceForIcons = function() {
+  var firstElementOnPad      = getPadInner().contents().find("#innerdocbody > div").first();
+  var rightMargin            = firstElementOnPad.css("margin-right");
+  var hasSpaceToDisplayIcons = rightMargin !== "0px";
+
+  return hasSpaceToDisplayIcons;
 }
 
 // Easier access to outer pad
@@ -100,6 +100,7 @@ var insertContainer = function() {
 
   getPadInner().before('<div id="commentIcons"></div>');
 
+  adjustIconsForNewScreenSize();
   addListeners();
 }
 
@@ -119,7 +120,7 @@ var addIcon = function(commentId, comment){
 // Hide comment icons from container
 var hideIcons = function() {
   // we're only doing something if icons will be displayed at all
-  if (!displayIcons()) return;
+  if (!displayIcons() || !screenHasSpaceForIcons()) return;
 
   getPadOuter().find('#commentIcons').children().children().each(function(){
     $(this).hide();
@@ -130,7 +131,7 @@ var hideIcons = function() {
 // height of the pad text associated to the comment, and return the affected icon
 var adjustTopOf = function(commentId, baseTop) {
   // we're only doing something if icons will be displayed at all
-  if (!displayIcons()) return;
+  if (!displayIcons() || !screenHasSpaceForIcons()) return;
 
   var icon = getPadOuter().find('#icon-'+commentId);
   var targetTop = baseTop+5;
@@ -148,7 +149,7 @@ var adjustTopOf = function(commentId, baseTop) {
 // comment icon.
 var isCommentOpenedByClickOnIcon = function() {
   // we're only doing something if icons will be displayed at all
-  if (!displayIcons()) return false;
+  if (!displayIcons() || !screenHasSpaceForIcons()) return false;
 
   var iconClicked = getPadOuter().find('#commentIcons').find(".comment-icon.active");
   var commentOpenedByClickOnIcon = iconClicked.length !== 0;
@@ -167,20 +168,31 @@ var commentHasReply = function(commentId) {
   iconForComment.addClass("with-reply");
 }
 
-// Indicate if comment should be shown, checking if it had the characteristics
+// Indicate if sidebar comment should be shown, checking if it had the characteristics
 // of a comment that was being displayed on the screen
-var shouldShow = function(commentElement) {
+var shouldShow = function(sidebarComent) {
   var shouldShowComment = false;
 
-  if (!displayIcons()) {
+  if (!displayIcons() || !screenHasSpaceForIcons()) {
     // if icons are not being displayed, we always show comments
     shouldShowComment = true;
-  } else if (commentElement.hasClass("mouseover")) {
+  } else if (sidebarComent.hasClass("mouseover")) {
     // if icons are being displayed, we only show comments clicked by user
     shouldShowComment = true;
   }
 
   return shouldShowComment;
+}
+
+var adjustIconsForNewScreenSize = function() {
+  // we're only doing something if icons will be displayed at all
+  if (!displayIcons()) return;
+
+  if (screenHasSpaceForIcons()) {
+    getPadOuter().find('#commentIcons').show();
+  } else {
+    getPadOuter().find('#commentIcons').hide();
+  }
 }
 
 exports.insertContainer = insertContainer;
@@ -190,3 +202,4 @@ exports.adjustTopOf = adjustTopOf;
 exports.isCommentOpenedByClickOnIcon = isCommentOpenedByClickOnIcon;
 exports.commentHasReply = commentHasReply;
 exports.shouldShow = shouldShow;
+exports.adjustIconsForNewScreenSize = adjustIconsForNewScreenSize;

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -1,0 +1,178 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var _ = require('ep_etherpad-lite/static/js/underscore');
+var commentBoxes = require('ep_comments_page/static/js/commentBoxes');
+
+// Easier access to outer pad
+var padOuter;
+var getPadOuter = function() {
+  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
+  return padOuter;
+}
+
+// easier access to inner pad
+var padInner;
+var getPadInner = function() {
+  padInner = padInner || getPadOuter().find('iframe[name="ace_inner"]');
+  return padInner;
+}
+
+var getOrCreateIconsContainerAt = function(top) {
+  var iconContainer = getPadOuter().find('#commentIcons');
+  var iconClass = "icon-at-"+top;
+
+  // is this the 1st comment on that line?
+  var iconsAtLine = iconContainer.find("."+iconClass);
+  var isFirstIconAtLine = iconsAtLine.length === 0;
+
+  // create container for icons at target line, if it does not exist yet
+  if (isFirstIconAtLine) {
+    iconContainer.append('<div class="comment-icon-line '+iconClass+'"></div>');
+    iconsAtLine = iconContainer.find("."+iconClass);
+    iconsAtLine.css("top", top+"px");
+  }
+
+  return iconsAtLine;
+}
+
+var targetCommentIdOf = function(e) {
+  return e.currentTarget.getAttribute("data-commentid");
+}
+
+var highlightTargetTextOf = function(commentId) {
+  getPadInner().contents().find("head").append("<style>."+commentId+"{ color:orange }</style>");
+}
+
+var removeHighlightOfTargetTextOf = function(commentId) {
+  getPadInner().contents().find("head").append("<style>."+commentId+"{ color:black }</style>");
+  // TODO this could potentially break ep_font_color
+}
+
+var toggleActiveCommentIcon = function(target) {
+  target.toggleClass("active").toggleClass("inactive");
+}
+
+var addListeners = function() {
+  getPadOuter().find('#commentIcons').on("mouseover", ".comment-icon", function(e){
+    var commentId = targetCommentIdOf(e);
+    highlightTargetTextOf(commentId);
+  }).on("mouseout", ".comment-icon", function(e){
+    var commentId = targetCommentIdOf(e);
+    removeHighlightOfTargetTextOf(commentId);
+  }).on("click", ".comment-icon.active", function(e){
+    toggleActiveCommentIcon($(this));
+
+    var commentId = targetCommentIdOf(e);
+    commentBoxes.hideComment(commentId, true);
+  }).on("click", ".comment-icon.inactive", function(e){
+    // deactivate/hide other comment boxes that are opened, so we have only
+    // one comment box opened at a time
+    commentBoxes.hideOpenedComments();
+    var allActiveIcons = getPadOuter().find('#commentIcons').find(".comment-icon.active");
+    toggleActiveCommentIcon(allActiveIcons);
+
+    // activate/show only target comment
+    toggleActiveCommentIcon($(this));
+    var commentId = targetCommentIdOf(e);
+    commentBoxes.showComment(commentId, e);
+  });
+}
+
+/* ***** Public methods: ***** */
+
+// Create container to hold comment icons
+var insertContainer = function() {
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return;
+
+  getPadInner().before('<div id="commentIcons"></div>');
+
+  addListeners();
+}
+
+// Create a new comment icon
+var addIcon = function(commentId, comment){
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return;
+
+  var inlineComment = getPadInner().contents().find(".comment."+commentId);
+  var top = inlineComment.get(0).offsetTop + 5;
+  var iconsAtLine = getOrCreateIconsContainerAt(top);
+  var icon = $('#commentIconTemplate').tmpl(comment);
+
+  icon.appendTo(iconsAtLine);
+}
+
+// Hide comment icons from container
+var hideIcons = function() {
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return;
+
+  getPadOuter().find('#commentIcons').children().children().each(function(){
+    $(this).hide();
+  });
+}
+
+// Adjust position of the comment icon on the container, to be on the same
+// height of the pad text associated to the comment, and return the affected icon
+var adjustTopOf = function(commentId, baseTop) {
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return;
+
+  var icon = getPadOuter().find('#icon-'+commentId);
+  var targetTop = baseTop+5;
+  var iconsAtLine = getOrCreateIconsContainerAt(targetTop);
+
+  // move icon from one line to the other
+  if (iconsAtLine != icon.parent()) icon.appendTo(iconsAtLine);
+
+  icon.show();
+
+  return icon;
+}
+
+// Indicate if comment detail currently opened was shown by a click on
+// comment icon.
+var isCommentOpenedByClickOnIcon = function() {
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return false;
+
+  var iconClicked = getPadOuter().find('#commentIcons').find(".comment-icon.active");
+  var commentOpenedByClickOnIcon = iconClicked.length !== 0;
+
+  return commentOpenedByClickOnIcon;
+}
+
+// Mark comment as a comment-with-reply, so it can be displayed with a
+// different icon
+var commentHasReply = function(commentId) {
+  // we're only doing something if icons will be displayed at all
+  if (!clientVars.displayCommentAsIcon) return;
+
+  // change comment icon
+  var iconForComment = getPadOuter().find('#commentIcons').find("#icon-"+commentId);
+  iconForComment.addClass("with-reply");
+}
+
+// Indicate if comment should be shown, checking if it had the characteristics
+// of a comment that was being displayed on the screen
+var shouldShow = function(commentElement) {
+  var shouldShowComment = false;
+
+  if (!clientVars.displayCommentAsIcon) {
+    // if icons are not being displayed, we always show comments
+    shouldShowComment = true;
+  } else if (commentElement.hasClass("mouseover")) {
+    // if icons are being displayed, we only show comments clicked by user
+    shouldShowComment = true;
+  }
+
+  return shouldShowComment;
+}
+
+exports.insertContainer = insertContainer;
+exports.addIcon = addIcon;
+exports.hideIcons = hideIcons;
+exports.adjustTopOf = adjustTopOf;
+exports.isCommentOpenedByClickOnIcon = isCommentOpenedByClickOnIcon;
+exports.commentHasReply = commentHasReply;
+exports.shouldShow = shouldShow;

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -2,6 +2,20 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var commentBoxes = require('ep_comments_page/static/js/commentBoxes');
 
+// Criteria to display (or not) comment as icons
+var displayIcons = function() {
+  var shouldDisplayIcons = false;
+  if (clientVars.displayCommentAsIcon) {
+    // we will only display icons if right margin has some space
+    var firstElementOnPad      = getPadInner().contents().find("#innerdocbody > div").first();
+    var rightMargin            = firstElementOnPad.css("margin-right");
+    var hasSpaceToDisplayIcons = rightMargin !== "0px";
+    shouldDisplayIcons         = hasSpaceToDisplayIcons;
+  }
+
+  return shouldDisplayIcons;
+}
+
 // Easier access to outer pad
 var padOuter;
 var getPadOuter = function() {
@@ -9,7 +23,7 @@ var getPadOuter = function() {
   return padOuter;
 }
 
-// easier access to inner pad
+// Easier access to inner pad
 var padInner;
 var getPadInner = function() {
   padInner = padInner || getPadOuter().find('iframe[name="ace_inner"]');
@@ -82,7 +96,7 @@ var addListeners = function() {
 // Create container to hold comment icons
 var insertContainer = function() {
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return;
+  if (!displayIcons()) return;
 
   getPadInner().before('<div id="commentIcons"></div>');
 
@@ -92,7 +106,7 @@ var insertContainer = function() {
 // Create a new comment icon
 var addIcon = function(commentId, comment){
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return;
+  if (!displayIcons()) return;
 
   var inlineComment = getPadInner().contents().find(".comment."+commentId);
   var top = inlineComment.get(0).offsetTop + 5;
@@ -105,7 +119,7 @@ var addIcon = function(commentId, comment){
 // Hide comment icons from container
 var hideIcons = function() {
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return;
+  if (!displayIcons()) return;
 
   getPadOuter().find('#commentIcons').children().children().each(function(){
     $(this).hide();
@@ -116,7 +130,7 @@ var hideIcons = function() {
 // height of the pad text associated to the comment, and return the affected icon
 var adjustTopOf = function(commentId, baseTop) {
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return;
+  if (!displayIcons()) return;
 
   var icon = getPadOuter().find('#icon-'+commentId);
   var targetTop = baseTop+5;
@@ -134,7 +148,7 @@ var adjustTopOf = function(commentId, baseTop) {
 // comment icon.
 var isCommentOpenedByClickOnIcon = function() {
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return false;
+  if (!displayIcons()) return false;
 
   var iconClicked = getPadOuter().find('#commentIcons').find(".comment-icon.active");
   var commentOpenedByClickOnIcon = iconClicked.length !== 0;
@@ -146,7 +160,7 @@ var isCommentOpenedByClickOnIcon = function() {
 // different icon
 var commentHasReply = function(commentId) {
   // we're only doing something if icons will be displayed at all
-  if (!clientVars.displayCommentAsIcon) return;
+  if (!displayIcons()) return;
 
   // change comment icon
   var iconForComment = getPadOuter().find('#commentIcons').find("#icon-"+commentId);
@@ -158,7 +172,7 @@ var commentHasReply = function(commentId) {
 var shouldShow = function(commentElement) {
   var shouldShowComment = false;
 
-  if (!clientVars.displayCommentAsIcon) {
+  if (!displayIcons()) {
     // if icons are not being displayed, we always show comments
     shouldShowComment = true;
   } else if (commentElement.hasClass("mouseover")) {

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -98,7 +98,7 @@ var insertContainer = function() {
   // we're only doing something if icons will be displayed at all
   if (!displayIcons()) return;
 
-  getPadInner().before('<div id="commentIcons"></div>');
+  getPadOuter().find("#sidediv").after('<div id="commentIcons"></div>');
 
   adjustIconsForNewScreenSize();
   addListeners();

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -1,0 +1,289 @@
+describe("Comment icons", function() {
+  //create a new pad with comment before each test run
+  beforeEach(function(cb){
+    helper.newPad(function() {
+      createComment(cb);
+    });
+    this.timeout(60000);
+  });
+
+  it("adds a comment icon on the same height of commented text", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var commentId = getCommentId();
+    var $commentIcon = outer$("#commentIcons #icon-"+commentId);
+
+    // check icon exists
+    expect($commentIcon.length).to.be(1);
+
+    // check height is the same
+    var $commentedText = inner$("."+commentId);
+    var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
+    expect($commentIcon.offset().top).to.be(expectedTop);
+
+    done();
+  });
+
+  it("does not show comment icon when commented text is removed", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+
+    // remove commented text
+    var $commentedLine = inner$("div .comment").parent();
+    $commentedLine.sendkeys('{selectall}'); // select all
+    $commentedLine.sendkeys('{del}'); // clear the first line
+    // wait until comment deletion is done
+    helper.waitFor(function() {
+      // check icon is not visible
+      var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+      return $commentIcons.length === 0;
+    })
+    .done(done);
+  });
+
+  it("does not show comment icon when comment is deleted", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+
+    deleteComment(function() {
+      // check icon is not visible
+      var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+      expect($commentIcons.length).to.be(0);
+
+      done();
+    });
+  });
+
+  it("updates comment icon height when commented text is moved to another line", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var commentId = getCommentId();
+
+    // adds some new lines on the beginning of the text
+    var $firstTextElement = inner$("div").first();
+    $firstTextElement.sendkeys('{leftarrow}{enter}{enter}');
+
+    // wait until the new lines are split into separated .ace-line's
+    helper.waitFor(function() {
+      return inner$("div").length > 2;
+    })
+    .done(function() {
+      // wait until comment is visible again
+      helper.waitFor(function() {
+        var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+        return $commentIcons.length !== 0;
+      })
+      .done(function() {
+        // check height is the same
+        var $commentIcon = outer$("#commentIcons #icon-"+commentId);
+        var $commentedText = inner$("."+commentId);
+        var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
+        expect($commentIcon.offset().top).to.be(expectedTop);
+
+        done();
+      });
+    });
+  });
+
+  it("shows comment modal when user clicks on comment icon", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    // force modal to be displayed, otherwise tests will fail on very large screens
+    chooseToShowComments(false, function() {
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+      var commentId = getCommentId();
+
+      // click on the icon
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+      $commentIcon.click();
+
+      // check modal is visible
+      var $commentModal = outer$(".comment-modal");
+      expect($commentModal.is(":visible")).to.be(true);
+
+      done();
+    });
+  });
+
+  it("hides comment modal when user clicks on comment icon twice", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    // force modal to be displayed, otherwise tests will fail on very large screens
+    chooseToShowComments(false, function() {
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+      var commentId = getCommentId();
+
+      // click on the icon to open, then click again to close
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+      $commentIcon.click();
+      $commentIcon.click();
+
+      // check modal is not visible
+      var $commentModal = outer$(".comment-modal");
+      expect($commentModal.is(":visible")).to.be(false);
+
+      done();
+    });
+  });
+
+  it("hides first comment and shows second comment when user clicks on one icon then on another icon", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done);
+
+    // force modal to be displayed, otherwise tests will fail on very large screens
+    chooseToShowComments(false, function() {
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+
+      // add a second line...
+      var $lastTextElement = inner$("div").last();
+      $lastTextElement.sendkeys('Second line');
+
+      // wait until the new line is split into a separated .ace-line
+      helper.waitFor(function() {
+        return inner$("div").length > 2;
+      })
+      .done(function() {
+        // ... then add a comment to second line
+        var $secondLine = inner$("div").eq(1);
+        $secondLine.sendkeys('{selectall}');
+        addComment("Second Comment", function() {
+          // click on the icon of first comment...
+          var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
+          $firstCommentIcon.click();
+          // ... then click on the icon of last comment
+          var $secondCommentIcon = outer$("#commentIcons #icon-"+getCommentId(1)).first();
+          $secondCommentIcon.click();
+
+          // check modal is visible
+          var $commentModalText = outer$(".comment-modal .comment-text").text();
+          expect($commentModalText).to.be("Second Comment");
+
+          done();
+
+        });
+      });
+    });
+  });
+
+  /* ********** Helper functions ********** */
+
+  var createComment = function(callback) {
+    var inner$ = helper.padInner$;
+
+    // get the first text element out of the inner iframe
+    var $firstTextElement = inner$("div").first();
+
+    // simulate key presses to delete content
+    $firstTextElement.sendkeys('{selectall}'); // select all
+    $firstTextElement.sendkeys('{del}'); // clear the first line
+    $firstTextElement.sendkeys('This content will receive a comment'); // insert text
+    // wait until the two lines are split into two .ace-line's
+    helper.waitFor(function() {
+      return inner$("div").length > 1;
+    })
+    .done(function() {
+      // add comment to last line of the text
+      var $lastTextElement = inner$("div").first();
+      $lastTextElement.sendkeys('{selectall}'); // need to select content to add comment to
+
+      addComment("My comment", callback);
+    });
+  }
+
+  // Assumes text is already selected, then add comment to the selected text
+  var addComment = function(commentText, callback) {
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var chrome$ = helper.padChrome$;
+
+    // get original number of comments, so can check if a new comment was created
+    var numberOfComments = inner$(".comment:visible").length;
+
+    // get the comment button and click it
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    // fill the comment form and submit it
+    var $commentField = outer$("textarea.comment-content");
+    $commentField.val(commentText);
+    // we don't need comment suggestion to be filled for these tests, but here's how to do it:
+    // var $hasSuggestion = outer$("#suggestion-checkbox");
+    // $hasSuggestion.click();
+    // var $suggestionField = outer$("textarea.comment-suggest-to");
+    // $suggestionField.val("Change to this suggestion");
+    var $submittButton = outer$("input[type=submit]");
+    $submittButton.click();
+
+    // wait until comment is created and comment id is set
+    helper.waitFor(function() {
+      return getCommentId(numberOfComments) !== null;
+    })
+    .done(callback);
+  }
+
+  var deleteComment = function(callback) {
+    var chrome$ = helper.padChrome$;
+    var outer$ = helper.padOuter$;
+
+    // click on the delete button
+    var $deleteButton = outer$(".comment-delete");
+    $deleteButton.click();
+
+    helper.waitFor(function() {
+      return chrome$(".sidebar-comment").is(":visible") === false;
+    })
+    .done(callback);
+  }
+
+
+  var getCommentId = function(numberOfComments) {
+    var nthComment = numberOfComments || 0;
+    var inner$ = helper.padInner$;
+    var comment = inner$(".comment").eq(nthComment);
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  }
+
+  var finishTestIfIconsAreNotEnabled = function(done) {
+    // #commentIcons will only be inserted if icons are enabled
+    if (helper.padOuter$("#commentIcons").length === 0) done();
+  }
+
+  var chooseToShowComments = function(shouldShowComments, callback) {
+    var chrome$ = helper.padChrome$;
+
+    //click on the settings button to make settings visible
+    var $settingsButton = chrome$(".buttonicon-settings");
+    $settingsButton.click();
+
+    //check "Show Comments"
+    var $showComments = chrome$('#options-comments')
+    if ($showComments.is(':checked') !== shouldShowComments) $showComments.click();
+
+    // hide settings again
+    $settingsButton.click();
+
+    callback();
+  }
+
+});

--- a/templates/commentIcons.html
+++ b/templates/commentIcons.html
@@ -1,0 +1,4 @@
+<script id="commentIconTemplate" type="text/html">
+    <div id="icon-${commentId}" class="comment-icon inactive" data-commentid="${commentId}">
+    </div>
+</script>


### PR DESCRIPTION
Addressing feature suggestion #36.

So this is another large commit, unfortunately I had to change a lot of places. I tried to keep the icons code as separated from the rest of the code as possible, but in order to be able to show/hide sidebar comments, I had to extract part of it to a separated file, so `static/js/index.js` had to be modified in several places.

Here are some details about this PR, I hope this makes the PR easier to be understood:

* icons can be enabled by a server-side setting (instructions are on README);
* some code related to sidebar comments was extracted to `static/js/commentBoxes.js`. Ideally we could have all code related to sidebar comments on that file, but this change might be too big to address now, and the PR would be even larger;
* during the development I've noticed `setYofComments()` was not being called when user changed screen size (for example when changing device orientation), so we would have something like this:
![image](https://cloud.githubusercontent.com/assets/836386/8114879/f7b22dc0-104d-11e5-9f4f-903805f5a05d.png)
  To reproduce: open pad in a small screen (small enough to not have top page margin), then change screen width until you're able to see top page margin. I fixed that issue [on this commit](https://github.com/JohnMcLear/ep_comments/commit/b22dfb99538bb56f2eecd389ab224dc7fbe959d5);
* `aceEditEvent` hook now calls `setYofComments()` instead of having the same code copied there. I wasn't sure I was testing all scenarios, so let me know if the solution I found is not working in some cases.

And, of course, if you have questions, comments, suggestions, etc, just let me know. :-)