### PR TITLE
Improvements to icons + Hiding 'Include suggested change'

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -78,14 +78,13 @@
   line-height:24px;
 }
 
-.comment-modal input{
-  display:none;
-}
-
 .comment-changeTo-approve{
   margin:0px 0px 10px 0px;
 }
 
+/* hide comment elements when displayed on modal, not on sidebar */
+.comment-modal .reply-comment-suggest,
+.comment-modal input,
 .comment-modal .comment-changeTo-approve{
   display:none;
 }

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -8,12 +8,18 @@ var displayIcons = function() {
 }
 
 // Indicates if screen has enough space on right margin to display icons
+var screenHasSpaceToDisplayIcons;
 var screenHasSpaceForIcons = function() {
-  var firstElementOnPad      = getPadInner().contents().find("#innerdocbody > div").first();
-  var rightMargin            = firstElementOnPad.css("margin-right");
-  var hasSpaceToDisplayIcons = rightMargin !== "0px";
+  if (screenHasSpaceToDisplayIcons === undefined) calculateIfScreenHasSpaceForIcons();
 
-  return hasSpaceToDisplayIcons;
+  return screenHasSpaceToDisplayIcons;
+}
+
+var calculateIfScreenHasSpaceForIcons = function() {
+  var firstElementOnPad = getPadInner().contents().find("#innerdocbody > div").first();
+  var rightMargin       = firstElementOnPad.css("margin-right");
+
+  screenHasSpaceToDisplayIcons = rightMargin !== "0px";
 }
 
 // Easier access to outer pad
@@ -187,6 +193,10 @@ var shouldShow = function(sidebarComent) {
 var adjustIconsForNewScreenSize = function() {
   // we're only doing something if icons will be displayed at all
   if (!displayIcons()) return;
+
+  // now that screen has a different size, we need to force calculation
+  // of flag used by screenHasSpaceForIcons() before calling the function
+  calculateIfScreenHasSpaceForIcons();
 
   if (screenHasSpaceForIcons()) {
     getPadOuter().find('#commentIcons').show();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -500,8 +500,6 @@ ep_comments.prototype.insertComment = function(commentId, comment, index, isNew)
 
   // insert icon
   if (!isNew) commentIcons.addIcon(commentId, comment);
-
-  this.setYofComments();
 };
 
 // Set all comments to be inline with their target REP

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -9,174 +9,174 @@ describe("Comment icons", function() {
 
   it("adds a comment icon on the same height of commented text", function(done) {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
+    finishTestIfIconsAreNotEnabled(done, function(){
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+      var commentId = getCommentId();
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId);
 
-    var inner$ = helper.padInner$;
-    var outer$ = helper.padOuter$;
-    var commentId = getCommentId();
-    var $commentIcon = outer$("#commentIcons #icon-"+commentId);
+      // check icon exists
+      expect($commentIcon.length).to.be(1);
 
-    // check icon exists
-    expect($commentIcon.length).to.be(1);
-
-    // check height is the same
-    var $commentedText = inner$("."+commentId);
-    var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
-    expect($commentIcon.offset().top).to.be(expectedTop);
-
-    done();
-  });
-
-  it("does not show comment icon when commented text is removed", function(done) {
-    // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
-
-    var inner$ = helper.padInner$;
-    var outer$ = helper.padOuter$;
-
-    // remove commented text
-    var $commentedLine = inner$("div .comment").parent();
-    $commentedLine.sendkeys('{selectall}'); // select all
-    $commentedLine.sendkeys('{del}'); // clear the first line
-    // wait until comment deletion is done
-    helper.waitFor(function() {
-      // check icon is not visible
-      var $commentIcons = outer$("#commentIcons .comment-icon:visible");
-      return $commentIcons.length === 0;
-    })
-    .done(done);
-  });
-
-  it("does not show comment icon when comment is deleted", function(done) {
-    // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
-
-    var inner$ = helper.padInner$;
-    var outer$ = helper.padOuter$;
-
-    deleteComment(function() {
-      // check icon is not visible
-      var $commentIcons = outer$("#commentIcons .comment-icon:visible");
-      expect($commentIcons.length).to.be(0);
+      // check height is the same
+      var $commentedText = inner$("."+commentId);
+      var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
+      expect($commentIcon.offset().top).to.be(expectedTop);
 
       done();
     });
   });
 
-  it("updates comment icon height when commented text is moved to another line", function(done) {
+  it("does not show comment icon when commented text is removed", function(done) {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
+    finishTestIfIconsAreNotEnabled(done, function(){
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
 
-    var inner$ = helper.padInner$;
-    var outer$ = helper.padOuter$;
-    var commentId = getCommentId();
-
-    // adds some new lines on the beginning of the text
-    var $firstTextElement = inner$("div").first();
-    $firstTextElement.sendkeys('{leftarrow}{enter}{enter}');
-
-    // wait until the new lines are split into separated .ace-line's
-    helper.waitFor(function() {
-      return inner$("div").length > 2;
-    })
-    .done(function() {
-      // wait until comment is visible again
+      // remove commented text
+      var $commentedLine = inner$("div .comment").parent();
+      $commentedLine.sendkeys('{selectall}'); // select all
+      $commentedLine.sendkeys('{del}'); // clear the first line
+      // wait until comment deletion is done
       helper.waitFor(function() {
+        // check icon is not visible
         var $commentIcons = outer$("#commentIcons .comment-icon:visible");
-        return $commentIcons.length !== 0;
+        return $commentIcons.length === 0;
       })
-      .done(function() {
-        // check height is the same
-        var $commentIcon = outer$("#commentIcons #icon-"+commentId);
-        var $commentedText = inner$("."+commentId);
-        var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
-        expect($commentIcon.offset().top).to.be(expectedTop);
+      .done(done);
+    });
+  });
+
+  it("does not show comment icon when comment is deleted", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done, function(){
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+
+      deleteComment(function() {
+        // check icon is not visible
+        var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+        expect($commentIcons.length).to.be(0);
 
         done();
       });
     });
   });
 
-  it("shows comment modal when user clicks on comment icon", function(done) {
+  it("updates comment icon height when commented text is moved to another line", function(done) {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
-
-    // force modal to be displayed, otherwise tests will fail on very large screens
-    chooseToShowComments(false, function() {
+    finishTestIfIconsAreNotEnabled(done, function(){
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
 
-      // click on the icon
-      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
-      $commentIcon.click();
+      // adds some new lines on the beginning of the text
+      var $firstTextElement = inner$("div").first();
+      $firstTextElement.sendkeys('{leftarrow}{enter}{enter}');
 
-      // check modal is visible
-      var $commentModal = outer$(".comment-modal");
-      expect($commentModal.is(":visible")).to.be(true);
+      // wait until the new lines are split into separated .ace-line's
+      helper.waitFor(function() {
+        return inner$("div").length > 2;
+      })
+      .done(function() {
+        // wait until comment is visible again
+        helper.waitFor(function() {
+          var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+          return $commentIcons.length !== 0;
+        })
+        .done(function() {
+          // check height is the same
+          var $commentIcon = outer$("#commentIcons #icon-"+commentId);
+          var $commentedText = inner$("."+commentId);
+          var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
+          expect($commentIcon.offset().top).to.be(expectedTop);
 
-      done();
+          done();
+        });
+      });
+    });
+  });
+
+  it("shows comment modal when user clicks on comment icon", function(done) {
+    // we only run test if icons are enabled
+    finishTestIfIconsAreNotEnabled(done, function(){
+      // force modal to be displayed, otherwise tests will fail on very large screens
+      chooseToShowComments(false, function() {
+        var inner$ = helper.padInner$;
+        var outer$ = helper.padOuter$;
+        var commentId = getCommentId();
+
+        // click on the icon
+        var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+        $commentIcon.click();
+
+        // check modal is visible
+        var $commentModal = outer$(".comment-modal");
+        expect($commentModal.is(":visible")).to.be(true);
+
+        done();
+      });
     });
   });
 
   it("hides comment modal when user clicks on comment icon twice", function(done) {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
+    finishTestIfIconsAreNotEnabled(done, function(){
+      // force modal to be displayed, otherwise tests will fail on very large screens
+      chooseToShowComments(false, function() {
+        var inner$ = helper.padInner$;
+        var outer$ = helper.padOuter$;
+        var commentId = getCommentId();
 
-    // force modal to be displayed, otherwise tests will fail on very large screens
-    chooseToShowComments(false, function() {
-      var inner$ = helper.padInner$;
-      var outer$ = helper.padOuter$;
-      var commentId = getCommentId();
+        // click on the icon to open, then click again to close
+        var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+        $commentIcon.click();
+        $commentIcon.click();
 
-      // click on the icon to open, then click again to close
-      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
-      $commentIcon.click();
-      $commentIcon.click();
+        // check modal is not visible
+        var $commentModal = outer$(".comment-modal");
+        expect($commentModal.is(":visible")).to.be(false);
 
-      // check modal is not visible
-      var $commentModal = outer$(".comment-modal");
-      expect($commentModal.is(":visible")).to.be(false);
-
-      done();
+        done();
+      });
     });
   });
 
   it("hides first comment and shows second comment when user clicks on one icon then on another icon", function(done) {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done);
+    finishTestIfIconsAreNotEnabled(done, function(){
+      // force modal to be displayed, otherwise tests will fail on very large screens
+      chooseToShowComments(false, function() {
+        var inner$ = helper.padInner$;
+        var outer$ = helper.padOuter$;
 
-    // force modal to be displayed, otherwise tests will fail on very large screens
-    chooseToShowComments(false, function() {
-      var inner$ = helper.padInner$;
-      var outer$ = helper.padOuter$;
+        // add a second line...
+        var $lastTextElement = inner$("div").last();
+        $lastTextElement.sendkeys('Second line');
 
-      // add a second line...
-      var $lastTextElement = inner$("div").last();
-      $lastTextElement.sendkeys('Second line');
+        // wait until the new line is split into a separated .ace-line
+        helper.waitFor(function() {
+          return inner$("div").length > 2;
+        })
+        .done(function() {
+          // ... then add a comment to second line
+          var $secondLine = inner$("div").eq(1);
+          $secondLine.sendkeys('{selectall}');
+          addComment("Second Comment", function() {
+            // click on the icon of first comment...
+            var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
+            $firstCommentIcon.click();
+            // ... then click on the icon of last comment
+            var $secondCommentIcon = outer$("#commentIcons #icon-"+getCommentId(1)).first();
+            $secondCommentIcon.click();
 
-      // wait until the new line is split into a separated .ace-line
-      helper.waitFor(function() {
-        return inner$("div").length > 2;
-      })
-      .done(function() {
-        // ... then add a comment to second line
-        var $secondLine = inner$("div").eq(1);
-        $secondLine.sendkeys('{selectall}');
-        addComment("Second Comment", function() {
-          // click on the icon of first comment...
-          var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
-          $firstCommentIcon.click();
-          // ... then click on the icon of last comment
-          var $secondCommentIcon = outer$("#commentIcons #icon-"+getCommentId(1)).first();
-          $secondCommentIcon.click();
+            // check modal is visible
+            var $commentModalText = outer$(".comment-modal .comment-text").text();
+            expect($commentModalText).to.be("Second Comment");
 
-          // check modal is visible
-          var $commentModalText = outer$(".comment-modal .comment-text").text();
-          expect($commentModalText).to.be("Second Comment");
+            done();
 
-          done();
-
+          });
         });
       });
     });
@@ -264,9 +264,10 @@ describe("Comment icons", function() {
     return commentId;
   }
 
-  var finishTestIfIconsAreNotEnabled = function(done) {
+  var finishTestIfIconsAreNotEnabled = function(done, theTest) {
     // #commentIcons will only be inserted if icons are enabled
     if (helper.padOuter$("#commentIcons").length === 0) done();
+    else theTest(done);
   }
 
   var chooseToShowComments = function(shouldShowComments, callback) {


### PR DESCRIPTION
After some tests with pads with 100+ comments, I've noticed sidebar comments were taking almost 10s to be shown, and comment icons were taking FOREVER. So here are some performance improvements (was able to reduce load time to 2s) + [hiding 'Include suggested change' when hovering over a comment](https://github.com/JohnMcLear/ep_comments/pull/46#issuecomment-111420618) + a fix for frontend tests when icons are disabled on `settings.json`.

I still need to [make icons work when ep_page_view is not installed](https://github.com/JohnMcLear/ep_comments/pull/46#issuecomment-111567221), will work on that on Monday.