### PR TITLE
textarea current text UI

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -145,6 +145,22 @@
   color:#000;
 }
 
+.comment-reply, .suggestion{
+  font-weight:bold;
+  color:#555
+}
+.reply-suggestion .reply-comment-suggest-from, .suggestion .comment-suggest-from, .comment-changeTo-value{
+  font-weight: normal;
+  color: black;
+  padding-left: 0.5em;
+  border-left: 2px solid #DDD;
+  max-height: 5em;
+  width: 178px;
+  overflow-y: auto;
+  white-space: normal;
+  line-height: 1.3em;
+}
+
 .sidebar-comment {
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -308,3 +324,4 @@
   margin-bottom:10px;
 /*  margin-left:40px; */
 }
+

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -153,6 +153,7 @@
   font-weight: normal;
   color: black;
   padding-left: 0.5em;
+  border:none;
   border-left: 2px solid #DDD;
   max-height: 5em;
   width: 178px;


### PR DESCRIPTION
Style changes for the current text-display for change suggestions. Currently it is still based on textarea.
 (since changing to p needed changes to the javascript, in prticular because textarea uses `.val()` while p should use `text()`. For setting the content, we  should not use `.html()` since arbitrary code might get injected. May be FUD, but I want to be careful)