### PR TITLE
Fix modal positioning for 2 scenarios

### DIFF
--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -25,14 +25,14 @@ var hideComment = function(commentId, hideCommentTitle) {
   // hide even the comment title
   if (hideCommentTitle) commentElm.hide();
 
-  getPadOuter().contents().find('.comment-modal').hide();
+  getPadOuter().find('.comment-modal').hide();
 };
 
 var hideOpenedComments = function() {
   var openedComments = getCommentsContainer().find('.mouseover');
   openedComments.removeClass('mouseover').hide();
 
-  getPadOuter().contents().find('.comment-modal').hide();
+  getPadOuter().find('.comment-modal').hide();
 }
 
 var hideAllComments = function() {
@@ -48,12 +48,22 @@ var highlightComment = function(commentId, e){
     commentElm.addClass('mouseover');
   } else {
     var commentElm = container.find('#'+ commentId);
-    getPadOuter().contents().find('.comment-modal').show().css({
-      left: e.clientX +"px",
+    // hovering comment view
+    getPadOuter().find('.comment-modal-comment').html(commentElm.html());
+
+    // get modal position
+    var containerWidth = getPadOuter().find('#outerdocbody').outerWidth(true);
+    var modalWitdh = getPadOuter().find('.comment-modal').outerWidth(true);
+    var targetLeft = e.clientX;
+    // if positioning modal on target left will make part of the modal to be
+    // out of screen, we place it closer to the middle of the screen
+    if (targetLeft + modalWitdh > containerWidth) {
+      targetLeft = containerWidth - modalWitdh - 2;
+    }
+    getPadOuter().find('.comment-modal').show().css({
+      left: targetLeft +"px",
       top: e.clientY + 25 +"px"
     });
-    // hovering comment view
-    getPadOuter().contents().find('.comment-modal-comment').html(commentElm.html());
   }
 }
 

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -55,6 +55,7 @@ var highlightComment = function(commentId, e){
     var containerWidth = getPadOuter().find('#outerdocbody').outerWidth(true);
     var modalWitdh = getPadOuter().find('.comment-modal').outerWidth(true);
     var targetLeft = e.clientX;
+    var targetTop = $(e.target).offset().top;
     // if positioning modal on target left will make part of the modal to be
     // out of screen, we place it closer to the middle of the screen
     if (targetLeft + modalWitdh > containerWidth) {
@@ -62,7 +63,7 @@ var highlightComment = function(commentId, e){
     }
     getPadOuter().find('.comment-modal').show().css({
       left: targetLeft +"px",
-      top: e.clientY + 25 +"px"
+      top: targetTop + 25 +"px"
     });
   }
 }


### PR DESCRIPTION
1. When comment is too close to the right margin, modal might be partially placed outside of the screen:
![image](https://cloud.githubusercontent.com/assets/836386/8241097/a76ea826-15dd-11e5-9f7c-75175d38757d.png)

2. [This affects only when icons are enabled] When comment is not on the beginning of the pad and user clicks the comment icon, the modal is placed on the incorrect height:
![image](https://cloud.githubusercontent.com/assets/836386/8241165/182f59ac-15de-11e5-98a8-4f9afd15c443.png)
