### PR TITLE
Cleanup of comment reply form after reply is submitted

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -284,7 +284,8 @@ ep_comments.prototype.init = function(){
 
     // On submit we should hide this suggestion no?
     if($(this).parent().parent().find(".reply-suggestion-checkbox").is(':checked')){
-      $(this).parent().parent().find(".reply-suggestion-checkbox:clicked").click();
+      $(this).parent().parent().find(".reply-suggestion-checkbox:checked").click();
+      $(this).parent().parent().find(".reply-comment-suggest-to").val("");
       //Only uncheck checked boxes. TODO: is a cleanup operation. Should we do it here?
     }
   });

--- a/static/tests/frontend/specs/commentDelete.js
+++ b/static/tests/frontend/specs/commentDelete.js
@@ -52,7 +52,6 @@ function createComment(callback) {
 
   // wait until comment is created and comment id is set
   helper.waitFor(function() {
-    console.log("HERE");
     return getCommentId() !== null;
   })
   .done(callback);
@@ -67,7 +66,6 @@ function deleteComment(callback){
   $deleteButton.click();
 
   helper.waitFor(function() {
-console.log(chrome$(".sidebar-comment").is(":visible") === false)
     return chrome$(".sidebar-comment").is(":visible") === false;
   })
   .done(callback);

--- a/static/tests/frontend/specs/commentReply.js
+++ b/static/tests/frontend/specs/commentReply.js
@@ -1,0 +1,155 @@
+describe("Comment Reply", function(){
+  //create a new pad with comment before each test run
+  beforeEach(function(cb){
+    helper.newPad(function() {
+      chooseToShowComments(true, function() {
+        createComment(function() {
+          // make sure Etherpad has enough space to display comments
+          $('#iframe-container iframe').css("max-width", "1000px");
+          cb();
+        });
+      });
+    });
+    this.timeout(60000);
+  });
+
+  after(function(cb) {
+    // undo what was done on before()
+    $('#iframe-container iframe').css("max-width", "");
+    cb();
+  });
+
+  it("Ensures a comment can be replied", function(done) {
+    createReply(false, function(){
+      done();
+    });
+  });
+
+  it("Ensures a comment reply can have suggestion", function(done) {
+    createReply(true, function(){
+      var outer$ = helper.padOuter$;
+      var $replySuggestion = outer$(".sidebar-comment-reply .comment-changeTo-form");
+      expect($replySuggestion.is(":visible")).to.be(true);
+      done();
+    });
+  });
+
+  it("Clears the comment reply form after submitting a reply with suggestion", function(done) {
+    createReply(true, function(){
+      var outer$ = helper.padOuter$;
+      var $replyForm = outer$("form.comment-reply");
+      var $replyField = $replyForm.find(".comment-reply-input");
+      var $replyWithSuggestionCheckbox = $replyForm.find(".reply-suggestion-checkbox");
+      var $replySuggestionTextarea = $replyForm.find(".reply-comment-suggest-to");
+      expect($replyField.text()).to.be("");
+      expect($replyWithSuggestionCheckbox.is(":checked")).to.be(false);
+      expect($replySuggestionTextarea.text()).to.be("");
+      done();
+    });
+  });
+
+  var createComment = function(callback) {
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var chrome$ = helper.padChrome$;
+
+    // get the first text element out of the inner iframe
+    var $firstTextElement = inner$("div").first();
+
+    // simulate key presses to delete content
+    $firstTextElement.sendkeys('{selectall}'); // select all
+    $firstTextElement.sendkeys('{del}'); // clear the first line
+    $firstTextElement.sendkeys('This content will receive a comment'); // insert text
+
+    // get the comment button and click it
+    $firstTextElement.sendkeys('{selectall}'); // needs to select content to add comment to
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    // fill the comment form and submit it
+    var $commentField = outer$("textarea.comment-content");
+    $commentField.val("My comment");
+    var $hasSuggestion = outer$("#suggestion-checkbox");
+    $hasSuggestion.click();
+    var $suggestionField = outer$("textarea.comment-suggest-to");
+    $suggestionField.val("Change to this suggestion");
+    var $submittButton = outer$("input[type=submit]");
+    $submittButton.click();
+
+    // wait until comment is created and comment id is set
+    helper.waitFor(function() {
+      return getCommentId() !== null;
+    })
+    .done(callback);
+  }
+
+  var createReply = function(withSuggestion, callback){
+    var outer$ = helper.padOuter$;
+    var commentId = getCommentId();
+    var existingReplies = outer$(".sidebar-comment-reply").length;
+
+    // if comment icons are enabled, make sure we display the comment box:
+    if (commentIconsEnabled()) {
+      // click on the icon
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+      $commentIcon.click();
+    }
+
+    // fill reply field
+    var $replyField = outer$(".comment-reply-input");
+    $replyField.val("My reply");
+
+    // fill suggestion
+    if (withSuggestion) {
+      // show suggestion field
+      var $replySuggestionCheckbox = outer$(".reply-suggestion-checkbox");
+      $replySuggestionCheckbox.click();
+
+      // fill suggestion field
+      var $suggestionField = outer$("textarea.reply-comment-suggest-to");
+      $suggestionField.val("My suggestion");
+    }
+
+    // submit reply
+    var $submitReplyButton = outer$("form.comment-reply input[type='submit']").first();
+    $submitReplyButton.click();
+
+    // wait for the reply to be saved
+    helper.waitFor(function() {
+      return outer$(".sidebar-comment-reply").length === existingReplies + 1;
+    })
+    .done(callback);
+  }
+
+  var getCommentId = function() {
+    var inner$ = helper.padInner$;
+    var comment = inner$(".comment").first();
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  }
+
+  var chooseToShowComments = function(shouldShowComments, callback) {
+    var chrome$ = helper.padChrome$;
+
+    //click on the settings button to make settings visible
+    var $settingsButton = chrome$(".buttonicon-settings");
+    $settingsButton.click();
+
+    //check "Show Comments"
+    var $showComments = chrome$('#options-comments')
+    if ($showComments.is(':checked') !== shouldShowComments) $showComments.click();
+
+    // hide settings again
+    $settingsButton.click();
+
+    callback();
+  }
+
+  var commentIconsEnabled = function() {
+    return helper.padOuter$("#commentIcons").length > 0;
+  }
+
+});

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -42,6 +42,8 @@
                     <textarea class="reply-comment-suggest-to"></textarea>
                 </p>
             </span>
+            <!-- for test purposes only -->
+            <input type="submit" style="display:none">
         </form>
     </div>
 </script>


### PR DESCRIPTION
This fixes the issue mentioned [on this message](https://github.com/JohnMcLear/ep_comments/pull/58#issuecomment-113316970).

Note: to be able to create a comment reply on the specs, I had to add a hidden submit button to the reply form. I've tried other ways before adding this button, but had no success on any. If anyone has any suggestion, I'll be happy to remove the submit button and change the specs. Here's what I've tried:

* To simulate an ENTER hit by the user on the reply input:
```
var $replyField = outer$(".comment-reply-input");
$replyField.focus().trigger(jQuery.Event('keypress', {which: 13}));
```
(it seems that the event is ignored, nothing happened when triggering it)

* To submit the form via javascript:
```
var $replyForm = outer$("form.comment-reply");
$replyForm.triggerHandler("submit");
```
(no handler is found)

* Calling `$replyForm.submit()` -- also does not work because this makes the page to be reloaded, thus the `socket.emit('addCommentReply', ...);` is not executed.