### PR TITLE
Bug fix: reply 'accept suggestion' works as 'revert suggestion'

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -906,7 +906,7 @@ ep_comments.prototype.showChangeAsAccepted = function(commentId){
 
   // Get the comment
   var comment = self.container.find("#"+commentId);
-  var button = comment.find("input[type='submit']");
+  var button = comment.find("input[type='submit']").first(); // we need to get the first button otherwise the replies suggestions will be affected too
   button.attr("data-l10n-id", "ep_comments_page.comments_template.revert_change.value");
   button.addClass("revert");
   self.localize(button);
@@ -917,7 +917,7 @@ ep_comments.prototype.showChangeAsReverted = function(commentId){
 
   // Get the comment
   var comment = self.container.find("#"+commentId);
-  var button = comment.find("input[type='submit']");
+  var button = comment.find("input[type='submit']").first(); // we need to get the first button otherwise the replies suggestions will be affected too
   button.attr("data-l10n-id", "ep_comments_page.comments_template.accept_change.value");
   button.removeClass("revert");
   self.localize(button);

--- a/static/tests/frontend/specs/commentReply.js
+++ b/static/tests/frontend/specs/commentReply.js
@@ -48,6 +48,44 @@ describe("Comment Reply", function(){
     });
   });
 
+  it("Replaces the original text with reply suggestion", function(done) {
+    createReply(true, function(){
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+
+      // click to accept suggested change of the reply
+      var $replyAcceptChangeButton = outer$(".sidebar-comment-reply .comment-changeTo-form input[type='submit']");
+      $replyAcceptChangeButton.click();
+
+      // check the pad text
+      var $firstTextElement = inner$("div").first();
+      expect($firstTextElement.text()).to.be("My suggestion");
+
+      done();
+    });
+  });
+
+  it("Replaces the original text with reply suggestion after replacing original text with comment suggestion", function(done) {
+    createReply(true, function(){
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+
+      // click to accept suggested change of the original comment
+      var $commentAcceptChangeButton = outer$(".sidebar-comment .comment-changeTo-form input[type='submit']").first();
+      $commentAcceptChangeButton.click();
+
+      // click to accept suggested change of the reply
+      var $replyAcceptChangeButton = outer$(".sidebar-comment-reply .comment-changeTo-form input[type='submit']");
+      $replyAcceptChangeButton.click();
+
+      // check the pad text
+      var $firstTextElement = inner$("div").first();
+      expect($firstTextElement.text()).to.be("My suggestion");
+
+      done();
+    });
+  });
+
   var createComment = function(callback) {
     var inner$ = helper.padInner$;
     var outer$ = helper.padOuter$;


### PR DESCRIPTION
To reproduce:
1. create a comment with a suggestion;
2. add a reply with a suggestion;
3. accept suggestion of original comment -- this replaces original text by the suggestion, which is correct;
4. accept suggestion of reply.

Expected: commented text should be the suggestion on the reply.
Actual: commented text is reverted to original text.

The issue was that by clicking on "Accept Change" of the original comment we were affecting all `input[type='submit']` buttons, including the ones on the replies. Fixed to only affect the one on the comment.