### PR TITLE
Break text lines on modal so long comments and replies fit the screen

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -48,6 +48,7 @@ time{
   display:block;
 }
 
+.comment-modal .comment-text,
 .sidebar-comment:hover .comment-text,
 .sidebar-comment.mouseover .comment-text{
   height:auto;
@@ -74,6 +75,7 @@ time{
 .comment-modal{
   position:absolute;
   min-width:20px;
+  max-width:50%;
   min-height:10px;
   background-color:#fff;
   z-index:99999;
@@ -114,7 +116,6 @@ time{
 }
 
 .comment-reply{
-  max-width:190px;
   margin-bottom:5px;
 }
 


### PR DESCRIPTION
To avoid this:
![image](https://cloud.githubusercontent.com/assets/836386/8408495/f5b9c0ee-1e46-11e5-857d-572eda8d5ff6.png)
