### PR TITLE
Removing unused element from New Form template

### DIFF
--- a/templates/comments.html
+++ b/templates/comments.html
@@ -50,9 +50,8 @@
 
 <script id="newCommentTemplate" type="text/html">
     <form id="newComment" class="sidebar-comment">
-    	<p class="comment-author-name">${name}</p>
         <p data-l10n-id="ep_comments_page.comment">Comment</p>
-    	<p class="comment-text">
+        <p class="comment-text">
             <textarea class="comment-content" autofocus></textarea>
         </p>
 


### PR DESCRIPTION
To avoid having unwanted box titles when using ep_comments + etherpad-lite-jquery-plugin (like this `epframeeditor`):

![image](https://cloud.githubusercontent.com/assets/836386/8412719/0b5643bc-1e62-11e5-8104-c6269ea6dc0f.png)

It seems that if `{name}` is `undefined` when using the template, browser gets the iframe `name` attribute. As `comment.name` is always `undefined` when showing the New Comment form, the `<p>` could be removed from the template.