### PR TITLE
Fix for iOS: when adding a comment, virtual keyboard is opened but text is not sent to textarea

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -142,6 +142,14 @@ ep_comments.prototype.init = function(){
     // console.log("setting focus to .comment-content");
     self.showNewCommentForm();
     $('iframe[name="ace_outer"]').contents().find('.comment-content').focus();
+
+    // fix for iOS: when opening #newComment, we need to force focus on padOuter
+    // contentWindow, otherwise keyboard will be displayed but text input made by
+    // the user won't be added to textarea
+    var outerIframe = $('iframe[name="ace_outer"]').get(0);
+    if (outerIframe && outerIframe.contentWindow) {
+      outerIframe.contentWindow.focus();
+    }
   });
 
   // Listen for include suggested change toggle


### PR DESCRIPTION
Apparently this happens only on iOS (Chrome and Safari), desktop browsers were ok: when user clicks button to add a comment, the #newComment form is displayed, textarea has focus, and virtual keyboard is available; but if user types anything, the text won't be added to the comment textarea.