### PR TITLE
UX on touch devices: Close opened comment when user touches outside of sidebar comment or modal

### DIFF
--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -85,6 +85,15 @@ var isOnTop = function(commentId, baseTop) {
   return commentElement.css("top") === expectedTop;
 }
 
+// Indicates if event was on one of the elements that does not close comment
+var shouldNotCloseComment = function(e) {
+  if ($(e.target).closest('.sidebar-comment').length // a comment box
+    || $(e.target).closest('.comment-modal').length) { // the comment modal
+    return true;
+  }
+  return false;
+}
+
 exports.showComment = showComment;
 exports.hideComment = hideComment;
 exports.hideOpenedComments = hideOpenedComments;
@@ -92,3 +101,4 @@ exports.hideAllComments = hideAllComments;
 exports.highlightComment = highlightComment;
 exports.adjustTopOf = adjustTopOf;
 exports.isOnTop = isOnTop;
+exports.shouldNotCloseComment = shouldNotCloseComment;

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -113,13 +113,16 @@ var addListenersToPageView = function() {
 // outside of it
 var addListenersToCloseOpenedComment = function() {
   // we need to add listeners to the different iframes of the page
-  $(document).on("click", function(e){
+  $(document).on("touchstart click", function(e){
+    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
-  getPadOuter().find('html').on("click", function(e){
+  getPadOuter().find('html').on("touchstart click", function(e){
+    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
-  getPadInner().find('html').on("click", function(e){
+  getPadInner().find('html').on("touchstart click", function(e){
+    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
 }
@@ -127,9 +130,8 @@ var addListenersToCloseOpenedComment = function() {
 // Close comment if event target was outside of comment or on a comment icon
 var closeOpenedCommentIfNotOnSelectedElements = function(e) {
   // Don't do anything if clicked on the following elements:
-  if ($(e.target).closest('.comment-icon').length // any of the comment icons
-    || $(e.target).closest('.sidebar-comment').length // a comment box
-    || $(e.target).closest('.comment-modal').length) { // the comment modal
+  if (shouldNotCloseComment(e) // any of the comment icons
+    || commentBoxes.shouldNotCloseComment(e)) { // a comment box or the comment modal
     return;
   }
 
@@ -138,7 +140,7 @@ var closeOpenedCommentIfNotOnSelectedElements = function(e) {
   if (openedComment) {
     toggleActiveCommentIcon($(openedComment));
 
-    var commentId = openedComment.getAttribute("data-commentid")
+    var commentId = openedComment.getAttribute("data-commentid");
     commentBoxes.hideComment(commentId, true);
   }
 }
@@ -258,6 +260,11 @@ var adjustIconsForNewScreenSize = function() {
   }
 }
 
+// Indicates if event was on one of the elements that does not close comment (any of the comment icons)
+var shouldNotCloseComment = function(e) {
+  return $(e.target).closest('.comment-icon').length !== 0;
+}
+
 exports.insertContainer = insertContainer;
 exports.addIcon = addIcon;
 exports.hideIcons = hideIcons;
@@ -266,3 +273,4 @@ exports.isCommentOpenedByClickOnIcon = isCommentOpenedByClickOnIcon;
 exports.commentHasReply = commentHasReply;
 exports.shouldShow = shouldShow;
 exports.adjustIconsForNewScreenSize = adjustIconsForNewScreenSize;
+exports.shouldNotCloseComment = shouldNotCloseComment;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -455,17 +455,49 @@ ep_comments.prototype.collectComments = function(callback){
   this.padInner.contents().on("mouseleave", ".comment", function(e){
     var commentOpenedByClickOnIcon = commentIcons.isCommentOpenedByClickOnIcon();
 
-    // only hides comment if it was not opened by a click on the icon
+    // only closes comment if it was not opened by a click on the icon
     if (!commentOpenedByClickOnIcon) {
-      var cls             = e.currentTarget.classList;
-      var classCommentId  = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
-      var commentId       = (classCommentId) ? classCommentId[1] : null;
-
-      commentBoxes.hideComment(commentId);
+      self.closeOpenedComment(e);
     }
   });
+
+  self.addListenersToCloseOpenedComment();
+
   self.setYofComments();
 };
+
+ep_comments.prototype.addListenersToCloseOpenedComment = function() {
+  var self = this;
+
+  // we need to add listeners to the different iframes of the page
+  $(document).on("touchstart", function(e){
+    self.closeOpenedCommentIfNotOnSelectedElements(e);
+  });
+  this.padOuter.find('html').on("touchstart", function(e){
+    self.closeOpenedCommentIfNotOnSelectedElements(e);
+  });
+  this.padInner.contents().find('html').on("touchstart", function(e){
+    self.closeOpenedCommentIfNotOnSelectedElements(e);
+  });
+}
+
+// Close comment that is opened
+ep_comments.prototype.closeOpenedComment = function(e) {
+  var commentId = this.commentIdOf(e);
+  commentBoxes.hideComment(commentId);
+}
+
+// Close comment if event target was outside of comment or on a comment icon
+ep_comments.prototype.closeOpenedCommentIfNotOnSelectedElements = function(e) {
+  // Don't do anything if clicked on the allowed elements:
+  if (commentIcons.shouldNotCloseComment(e) // any of the comment icons
+    || commentBoxes.shouldNotCloseComment(e)) { // a comment box or the comment modal
+    return;
+  }
+
+  // All clear, can close the comment
+  this.closeOpenedComment(e);
+}
 
 // Collect Comments and link text content to the comments div
 ep_comments.prototype.collectCommentReplies = function(callback){


### PR DESCRIPTION
Similar to #63, but for touch events.