### PR TITLE
Blurring new comment form when hiding it, so mobile devices can hide the virtual keyboard.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -345,6 +345,10 @@ ep_comments.prototype.showNewCommentForm = function(){
 ep_comments.prototype.hideNewCommentForm = function(){
   var self = this;
   this.newCommentContainer.find('#newComment').removeClass("visible").addClass("hidden");
+
+  // force focus to be lost, so virtual keyboard is hidden on mobile devices
+  this.newCommentContainer.find(':focus').blur();
+
   // we need to give some time for the animation of #newComment to finish
   window.setTimeout(function() {
     self.newCommentContainer.removeClass("active");


### PR DESCRIPTION
Otherwise we would still have the virtual keyboard opened after clicking the 'Cancel' button:

![image](https://cloud.githubusercontent.com/assets/836386/8706536/a7022bf4-2b06-11e5-8d6c-5a99da728919.png)
![image](https://cloud.githubusercontent.com/assets/836386/8706540/acedef44-2b06-11e5-9bf7-8c8303b80664.png)
