### PR TITLE
Avoid a 'flying' toolbar on iOS when adding a comment.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -120,7 +120,7 @@ ep_comments.prototype.init = function(){
 
   // When screen size changes (user changes device orientation, for example),
   // we need to make sure all sidebar comments are on the correct place
-  this.waitForResizeToFinishThenCall(function() {
+  newComment.waitForResizeToFinishThenCall(200, function() {
     self.editorResized();
   });
 
@@ -567,18 +567,6 @@ ep_comments.prototype.setYofComments = function(){
     commentEle.show();
   });
 };
-
-// Some browsers trigger resize several times while resizing the window, so
-// we need to make sure resize is done to avoid calling the callback multiple
-// times.
-// Based on: https://css-tricks.com/snippets/jquery/done-resizing-event/
-ep_comments.prototype.waitForResizeToFinishThenCall = function(callback){
-  var resizeTimer;
-  $(window).on("resize", function() {
-    clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(callback, 200);
-  });
-}
 
 // Make the adjustments after editor is resized (due to a window resize or
 // enabling/disabling Page View)


### PR DESCRIPTION
This is a clean copy of #74.

This should be a general fix for Etherpad, but for now it was the only
way I found to fix the issue. Works on read-write and read-only pads.

Fixing issue [2743](https://github.com/ether/etherpad-lite/pull/2743) of Etherpad might be enough to remove this commit.