### PR TITLE
Mark text being commented

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ cd node_modules/ep_comments_page
 npm install
 ```
 
-## Alternative comment display
-The plugin also provides an alternative way to display comments. Instead of having all comments visible on the right of the page, you can have just an icon on the right margin of the page. Comment details are displayed when user clicks on the comment icon:
+## Extra settings
+This plugin has some extra features that can be enabled by changing values on `settings.json` of your Etherpad instance.
+
+### Alternative comment display
+There is an alternative way to display comments. Instead of having all comments visible on the right of the page, you can have just an icon on the right margin of the page. Comment details are displayed when user clicks on the comment icon:
 
 ![Screen shot](http://i.imgur.com/cEo7PdL.png)
 
@@ -22,6 +25,20 @@ To use this way of displaying comments, **make sure you have installed [ep_page_
   "displayCommentAsIcon": true
 },
 ```
+
+### Highlight selected text when creating a comment
+It is also possible to mark the text originally selected when user adds a comment:
+![Screen shot](http://i.imgur.com/AhaVgRZ.png)
+
+To enable this feature, add the following code to your `settings.json`:
+```
+// Highlight selected text when adding comment
+"ep_comments_page": {
+  "highlightSelectedText": true
+},
+```
+
+**Warning**: there is a side effect when you enable this feature: a revision is created everytime the text is highlighted, resulting on apparently "empty" changes when you check your pad on the timeslider. If that is an issue for you, we don't recommend you to use this feature.
 
 ## Creating comment via API
 If you need to add comments to a pad:

--- a/index.js
+++ b/index.js
@@ -149,7 +149,11 @@ exports.eejsBlock_styles = function (hook_name, args, cb) {
 
 exports.clientVars = function (hook, context, cb) {
   var displayCommentAsIcon = settings.ep_comments_page ? settings.ep_comments_page.displayCommentAsIcon : false;
-  return cb({ "displayCommentAsIcon": displayCommentAsIcon });
+  var highlightSelectedText = settings.ep_comments_page ? settings.ep_comments_page.highlightSelectedText : false;
+  return cb({
+    "displayCommentAsIcon": displayCommentAsIcon,
+    "highlightSelectedText": highlightSelectedText,
+  });
 };
 
 exports.expressCreateServer = function (hook_name, args, callback) {

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -2,13 +2,13 @@ note{
   display:block;
 }
 
-.pre-selected-comment {
-  background: #FFE168 !important;
-}
-
 .comment {
   background: #FFFACD !important;
   border-radius: 0px;
+}
+
+.pre-selected-comment {
+  background: #FFE168 !important;
 }
 
 .comment-delete-container{

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -2,6 +2,10 @@ note{
   display:block;
 }
 
+.pre-selected-comment {
+  background: #FFE168 !important;
+}
+
 .comment {
   background: #FFFACD !important;
   border-radius: 0px;

--- a/static/js/newComment.js
+++ b/static/js/newComment.js
@@ -160,6 +160,9 @@ var showNewCommentForm = function() {
     getPadOuter().find('.suggestion').hide(); // Hides suggestion in case of a cancel
     getNewCommentContainer().find('#newComment').removeClass("hidden").addClass("visible");
   }, 0);
+
+  // mark selected text, so it is clear to user which text range the comment is being applied to
+  pad.plugins.ep_comments_page.preCommentMarker.markSelectedText();
 }
 
 var hideNewCommentForm = function() {
@@ -172,6 +175,9 @@ var hideNewCommentForm = function() {
   window.setTimeout(function() {
     getNewCommentContainer().removeClass("active");
   }, 500);
+
+  // unmark selected text, as now there is no text being commented
+  pad.plugins.ep_comments_page.preCommentMarker.unmarkSelectedText();
 }
 
 // Some browsers trigger resize several times while resizing the window, so

--- a/static/js/preCommentMark.js
+++ b/static/js/preCommentMark.js
@@ -1,0 +1,86 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+exports.MARK_CLASS = 'pre-selected-comment';
+
+var preCommentMarker = function(ace) {
+  this.ace = ace;
+  var self = this;
+
+  // remove any existing marks, as there is no comment being added on plugin initialization
+  // (we need the timeout to let the plugin be fully initialized before starting to remove
+  // marked texts)
+  setTimeout(function() {
+    self.unmarkSelectedText();
+  }, 0);
+}
+
+preCommentMarker.prototype.markSelectedText = function() {
+  this.ace.callWithAce(doNothing, 'markPreSelectedTextToComment', true);
+}
+
+preCommentMarker.prototype.unmarkSelectedText = function() {
+  this.ace.callWithAce(doNothing, 'unmarkPreSelectedTextToComment', true);
+}
+
+preCommentMarker.prototype.performNonUnduableEvent = function(eventType, callstack, action) {
+  callstack.startNewEvent("nonundoable");
+  action();
+  callstack.startNewEvent(eventType);
+}
+
+preCommentMarker.prototype.handleMarkText = function(context) {
+  var editorInfo = context.editorInfo;
+  var rep        = context.rep;
+  var callstack  = context.callstack;
+
+  // first we need to unmark any existing text, otherwise we'll have 2 text ranges marked
+  this.removeMarks(editorInfo, rep, callstack);
+
+  this.addMark(editorInfo, callstack);
+}
+
+preCommentMarker.prototype.handleUnmarkText = function(context) {
+  var editorInfo = context.editorInfo;
+  var rep        = context.rep;
+  var callstack  = context.callstack;
+
+  this.removeMarks(editorInfo, rep, callstack);
+}
+
+preCommentMarker.prototype.addMark = function(editorInfo, callstack) {
+  var eventType  = callstack.editEvent.eventType;
+
+  // we don't want the text marking to be undoable
+  this.performNonUnduableEvent(eventType, callstack, function() {
+    editorInfo.ace_setAttributeOnSelection(exports.MARK_CLASS, clientVars.userId);
+  });
+}
+
+preCommentMarker.prototype.removeMarks = function(editorInfo, rep, callstack) {
+  var eventType        = callstack.editEvent.eventType;
+  var originalSelStart = rep.selStart;
+  var originalSelEnd   = rep.selEnd;
+
+  // we don't want the text marking to be undoable
+  this.performNonUnduableEvent(eventType, callstack, function() {
+    // remove marked text
+    var padInner = $('iframe[name="ace_outer"]').contents().find('iframe[name="ace_inner"]');
+    var selector = "." + exports.MARK_CLASS;
+    var repArr = editorInfo.ace_getRepFromSelector(selector, padInner);
+    // repArr is an array of reps
+    $.each(repArr, function(index, rep){
+      editorInfo.ace_performSelectionChange(rep[0], rep[1], true);
+      editorInfo.ace_setAttributeOnSelection(exports.MARK_CLASS, false);
+    });
+
+    // make sure selected text is back to original value
+    editorInfo.ace_performSelectionChange(originalSelStart, originalSelEnd, true);
+  });
+}
+
+// we do nothing on callWithAce; actions will be handled on aceEditEvent
+var doNothing = function() {}
+
+exports.init = function(ace) {
+  return new preCommentMarker(ace);
+}

--- a/static/js/preCommentMark.js
+++ b/static/js/preCommentMark.js
@@ -6,6 +6,9 @@ var preCommentMarker = function(ace) {
   this.ace = ace;
   var self = this;
 
+  // do nothing if this feature is not enabled
+  if (!this.highlightSelectedText()) return;
+
   // remove any existing marks, as there is no comment being added on plugin initialization
   // (we need the timeout to let the plugin be fully initialized before starting to remove
   // marked texts)
@@ -14,11 +17,22 @@ var preCommentMarker = function(ace) {
   }, 0);
 }
 
+// Indicates if Etherpad is configured to highlight text
+preCommentMarker.prototype.highlightSelectedText = function() {
+  return clientVars.highlightSelectedText;
+}
+
 preCommentMarker.prototype.markSelectedText = function() {
+  // do nothing if this feature is not enabled
+  if (!this.highlightSelectedText()) return;
+
   this.ace.callWithAce(doNothing, 'markPreSelectedTextToComment', true);
 }
 
 preCommentMarker.prototype.unmarkSelectedText = function() {
+  // do nothing if this feature is not enabled
+  if (!this.highlightSelectedText()) return;
+
   this.ace.callWithAce(doNothing, 'unmarkPreSelectedTextToComment', true);
 }
 

--- a/static/tests/frontend/specs/preCommentMark.js
+++ b/static/tests/frontend/specs/preCommentMark.js
@@ -1,0 +1,219 @@
+describe("Pre-comment text mark", function() {
+  var padId;
+
+  //create a new pad before each test run
+  beforeEach(function(cb){
+    padId = helper.newPad(function() {
+      createPadWithTwoLines(function() {
+        selectLineAndOpenCommentForm(0, cb);
+      });
+    });
+    this.timeout(60000);
+  });
+
+  it("marks selected text when New Comment form is opened", function(done) {
+    var inner$ = helper.padInner$;
+
+    // verify if text was marked with pre-comment class
+    var $preCommentTextMarked = inner$(".pre-selected-comment");
+    expect($preCommentTextMarked.length).to.be(1);
+    expect($preCommentTextMarked.text()).to.be("Line 1");
+
+    done();
+  });
+
+  context("when user reloads pad", function() {
+    beforeEach(function(cb) {
+      this.timeout(5000);
+
+      // wait for changes to be saved as a revision before reloading the pad, otherwise
+      // it won't have the text that we created on beforeEach after reload
+      setTimeout(function() {
+        helper.newPad(cb, padId);
+      }, 1000);
+    });
+
+    it("does not have any marked text after pad is fully loaded", function(done) {
+      var inner$ = helper.padInner$;
+
+      // it takes some time for marks to be removed, so wait for it
+      helper.waitFor(function() {
+        var $preCommentTextMarked = inner$(".pre-selected-comment");
+        return $preCommentTextMarked.length === 0;
+      }).done(done);
+    });
+  });
+
+  context("when user performs UNDO operation", function() {
+    beforeEach(function(cb) {
+      this.timeout(5000);
+
+      // wait for changes to be saved as a revision and reload pad, otherwise
+      // UNDO will remove the text that we created on beforeEach
+      setTimeout(function() {
+        helper.newPad(cb, padId);
+      }, 1000);
+    });
+
+    it("keeps marked text", function(done) {
+      var chrome$ = helper.padChrome$;
+      var inner$ = helper.padInner$;
+
+      // marks text
+      selectLineAndOpenCommentForm(0, function() {
+        // perform UNDO
+        var $undoButton = chrome$(".buttonicon-undo");
+        $undoButton.click();
+
+        // verify if text was marked with pre-comment class
+        var $preCommentTextMarked = inner$(".pre-selected-comment");
+        expect($preCommentTextMarked.length).to.be(1);
+        expect($preCommentTextMarked.text()).to.be("Line 1");
+
+        done();
+      });
+    });
+  });
+
+  context("when user changes selected text", function() {
+    beforeEach(function(cb) {
+      var inner$ = helper.padInner$;
+
+      // select second line of text
+      var $secondLine = inner$("div").first().next();
+      $secondLine.sendkeys("{selectall}");
+
+      cb();
+    });
+
+    it("keeps marked text", function(done) {
+      var inner$ = helper.padInner$;
+
+      // verify if text was marked with pre-comment class
+      var $preCommentTextMarked = inner$(".pre-selected-comment");
+      expect($preCommentTextMarked.length).to.be(1);
+      expect($preCommentTextMarked.text()).to.be("Line 1");
+
+      done();
+    });
+  });
+
+  context("when user closes the New Comment form", function() {
+    beforeEach(function(cb) {
+      var outer$ = helper.padOuter$;
+
+      var $cancelButton = outer$("#comment-reset");
+      $cancelButton.click();
+
+      cb();
+    });
+
+    it("unmarks text", function(done) {
+      var inner$ = helper.padInner$;
+
+      // verify if there is no text marked with pre-comment class
+      var $preCommentTextMarked = inner$(".pre-selected-comment");
+      expect($preCommentTextMarked.length).to.be(0);
+
+      done();
+    });
+  });
+
+  context("when user submits the comment", function() {
+    beforeEach(function(cb) {
+      var outer$ = helper.padOuter$;
+
+      // fill the comment form and submit it
+      var $commentField = outer$("textarea.comment-content");
+      $commentField.val("My comment");
+      var $hasSuggestion = outer$("#suggestion-checkbox");
+      $hasSuggestion.click();
+      var $suggestionField = outer$("textarea.comment-suggest-to");
+      $suggestionField.val("Change to this suggestion");
+      var $submittButton = outer$("input[type=submit]");
+      $submittButton.click();
+
+      // wait until comment is created and comment id is set
+      helper.waitFor(function() {
+        return getCommentId() !== null;
+      }).done(cb);
+    });
+
+    it("unmarks text", function(done) {
+      var inner$ = helper.padInner$;
+
+      // verify if there is no text marked with pre-comment class
+      var $preCommentTextMarked = inner$(".pre-selected-comment");
+      expect($preCommentTextMarked.length).to.be(0);
+
+      done();
+    });
+  });
+
+  context("when user selects another text range and opens New Comment form for it", function() {
+    beforeEach(function(cb) {
+      selectLineAndOpenCommentForm(1, cb);
+    });
+
+    it("changes the marked text", function(done) {
+      var inner$ = helper.padInner$;
+
+      // verify if text was marked with pre-comment class
+      var $preCommentTextMarked = inner$(".pre-selected-comment");
+      expect($preCommentTextMarked.length).to.be(1);
+      expect($preCommentTextMarked.text()).to.be("Line 2");
+
+      done();
+    });
+  });
+
+  /* ********** Helper functions ********** */
+  var createPadWithTwoLines = function(callback) {
+    var inner$ = helper.padInner$;
+
+    // replace the first text element of pad with two lines
+    var $firstLine = inner$("div").first();
+    $firstLine.html("Line 1<br/>Line 2<br/>");
+
+    // wait until the two lines are split into two divs
+    helper.waitFor(function() {
+      var $secondLine = inner$("div").first().next();
+      return $secondLine.text() === "Line 2";
+    }).done(callback);
+  }
+
+  var selectLineAndOpenCommentForm = function(lineNumber, callback) {
+    var inner$ = helper.padInner$;
+    var chrome$ = helper.padChrome$;
+
+    // select first line to add comment to
+    var $targetLine = getLine(lineNumber);
+    $targetLine.sendkeys("{selectall}");
+
+    // get the comment button and click it
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    callback();
+  }
+
+  var getCommentId = function() {
+    var inner$ = helper.padInner$;
+    var comment = inner$(".comment").first();
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  }
+
+  var getLine = function(lineNumber) {
+    var inner$ = helper.padInner$;
+    var line = inner$("div").first();
+    for (var i = lineNumber - 1; i >= 0; i--) {
+      line = line.next();
+    }
+    return line;
+  }
+
+});

--- a/static/tests/frontend/specs/preCommentMark.js
+++ b/static/tests/frontend/specs/preCommentMark.js
@@ -4,6 +4,11 @@ describe("Pre-comment text mark", function() {
   //create a new pad before each test run
   beforeEach(function(cb){
     padId = helper.newPad(function() {
+      // can only run this suite if text highlight is enabled
+      if (textHighlightIsDisabled()) {
+        throw new Error("Cannot test pre-comment text mark. Feature disabled. Please change your settings.json");
+      }
+
       createPadWithTwoLines(function() {
         selectLineAndOpenCommentForm(0, cb);
       });
@@ -214,6 +219,10 @@ describe("Pre-comment text mark", function() {
       line = line.next();
     }
     return line;
+  }
+
+  var textHighlightIsDisabled = function() {
+    return !helper.padChrome$.window.clientVars.highlightSelectedText;
   }
 
 });


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/836386/11573707/d7ee78c4-99ee-11e5-969e-b331758c9e1c.png)


When new comment form is displayed, mark the target text with some
background color, so user knows which text will receive the comment even
if text selection is changed while form is being displayed or if user
performs UNDO after opening the form.

Marks are removed whenever the form is closed (cancel/submit) and on
pad loading.

Only shows marked text to the user who opened the form -- so if we have
two users viewing the same pad they will only see the marks made by
them.

Timeslider does not show any marked text.