### PR TITLE
Copy comment or part of it

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -3,6 +3,7 @@ note{
 }
 
 .comment {
+  /*WARNING: if you change this value, you need to change it too on copyPasteEvents.js, otherwise you'll break part of the copy/paste behavior"*/
   background: #FFFACD !important;
   border-radius: 0px;
 }

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -85,7 +85,7 @@ exports.addCommentClasses = function(e){
   var commentId = e.originalEvent.clipboardData.getData('text/copyCommentId');
   var target = e.target;
   if (commentId) {
-    // we need to wait the paste process finishes completely, otherwise we will not have the target to add the necessaries classes
+    // we need to wait the paste process finishes completely, otherwise we will not have the target to add the necessary classes
     setTimeout(function() {
       addCommentClassesOnline(target, commentId);
     }, 0);
@@ -93,9 +93,9 @@ exports.addCommentClasses = function(e){
 };
 
 var addCommentClassesOnline = function (target, commentId) {
-  var emptyLine = pasteOnEmptyLine(target);
+  var pastingOnEmptyLine = isEmptyLine(target);
   var targetElement;
-  if (emptyLine){
+  if (pastingOnEmptyLine){
     targetElement = $(target).parent();
   }else{
     targetElement = getTargetOnLineWithContent();
@@ -112,7 +112,7 @@ var getTargetOnLineWithContent = function() {
 };
 
 // an empty line has only a <br>
-var pasteOnEmptyLine = function(target) {
+var isEmptyLine = function(target) {
   return $(target).is("br");
 };
 

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,0 +1,134 @@
+exports.addTextOnClipboard = function(e, ace, padInner){
+  var commentIdOnSelection;
+  ace.callWithAce(function(ace) {
+    commentIdOnSelection = ace.ace_getCommentIdOnSelection();
+  });
+  // we check if all the selection is in the same comment, if so, we override the copy behavior
+  if (commentIdOnSelection) {
+    var range = padInner.contents()[0].getSelection().getRangeAt(0);
+    var hiddenDiv = createHiddenDiv(range);
+    var html = getHtml(hiddenDiv);
+    // when the range selection is fully inside a tag, 'html' will have no HTML tag, so we have to
+    // build it. Ex: if we have '<span>ab<b>cdef</b>gh</span>" and user selects 'de', the value of
+    //'html' will be 'de', not '<b>de</b>'
+    if (selectionHasOnlyText(html, hiddenDiv)) {
+      html = buildHtmlToCopy(html, range);
+      e.originalEvent.clipboardData.setData('text/copyCommentId', commentIdOnSelection);
+    }
+    // here we override the default copy behavior
+    e.originalEvent.clipboardData.setData('text/html', html);
+    e.preventDefault();
+  }
+};
+
+var createHiddenDiv = function(range){
+  var content = range.cloneContents();
+  var div = document.createElement("div");
+  var hiddenDiv = $(div).html(content);
+  return hiddenDiv;
+};
+
+var getHtml = function(hiddenDiv){
+  return $(hiddenDiv).html();
+};
+
+var selectionHasOnlyText = function(html, hiddenDiv){
+  var htmlDecoded = htmlDecode(html);
+  var text = $(hiddenDiv).text();
+  return htmlDecoded === text;
+};
+
+var buildHtmlToCopy = function(html, range) {
+  var htmlOfParentNode = range.commonAncestorContainer.parentNode;
+  var tags = getTagsInSelection(htmlOfParentNode);
+  // this case happens when we got a selection with one or more styling (bold, italic, underline, strikethrough)
+  // applied in all selection in the same range. For example, <b><i><u>text</u></i></b>
+  if(tags){
+    html = buildOpenTags(tags) + html + buildCloseTags(tags);
+  }
+  var htmlToCopy = "<span class='comment'>" + html + "</span>";
+  return htmlToCopy;
+};
+
+
+var buildOpenTags = function(tags){
+  var openTags = "";
+  tags.forEach(function(tag){
+    openTags += "<"+tag+">";
+  });
+  return openTags;
+};
+
+var buildCloseTags = function(tags){
+  var closeTags = "";
+  var tags = tags.reverse();
+  tags.forEach(function(tag){
+    closeTags += "</"+tag+">";
+  });
+  return closeTags;
+};
+
+var getTagsInSelection = function(htmlObject){
+  var tags = [];
+  var tag;
+  while($(htmlObject)[0].localName != "span"){
+    var html = $(htmlObject).prop('outerHTML');
+    var stylingTagRegex = /<(b|i|u|s)>/.exec(html);
+    tag = stylingTagRegex ? stylingTagRegex[1] : "";
+    tags.push(tag);
+    htmlObject = $(htmlObject).parent();
+  }
+  return tags;
+}
+
+exports.addCommentClasses = function(e){
+  var commentId = e.originalEvent.clipboardData.getData('text/copyCommentId');
+  var target = e.target;
+  if (commentId) {
+    // we need to wait the paste process finishes completely, otherwise we will not have the target to add the necessaries classes
+    setTimeout(function() {
+      addCommentClassesOnline(target, commentId);
+    }, 0);
+  }
+};
+
+var addCommentClassesOnline = function (target, commentId) {
+  var emptyLine = pasteOnEmptyLine(target);
+  var targetElement;
+  if (emptyLine){
+    targetElement = $(target).parent();
+  }else{
+    targetElement = getTargetOnLineWithContent();
+  }
+  targetElement.addClass(commentId).addClass('comment');
+};
+
+
+var getTargetOnLineWithContent = function() {
+  var padOuter = $('iframe[name="ace_outer"]').contents();
+  var padInner = padOuter.find('iframe[name="ace_inner"]').contents();
+  var target = padInner.find("span[style='background-color: rgb(255, 250, 205);']");
+  return target;
+};
+
+// an empty line has only a <br>
+var pasteOnEmptyLine = function(target) {
+  return $(target).is("br");
+};
+
+// copied from https://css-tricks.com/snippets/javascript/unescape-html-in-js/
+var htmlDecode = function(input) {
+  var e = document.createElement('div');
+  e.innerHTML = input;
+  return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+};
+
+exports.getCommentIdOnSelection = function() {
+  var attributeManager = this.documentAttributeManager;
+  var rep = this.rep;
+  var selStartAttrib = _.object(attributeManager.getAttributesOnPosition(rep.selStart[0], rep.selStart[1])).comment;
+  var selEndAttrib = _.object(attributeManager.getAttributesOnPosition(rep.selEnd[0], rep.selEnd[1] - 1)).comment;
+  return selStartAttrib === selEndAttrib ? selStartAttrib : null;
+};
+
+

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -15,6 +15,8 @@ var commentIcons = require('ep_comments_page/static/js/commentIcons');
 var newComment = require('ep_comments_page/static/js/newComment');
 var preCommentMark = require('ep_comments_page/static/js/preCommentMark');
 var commentL10n = require('ep_comments_page/static/js/commentL10n');
+var events = require('ep_comments_page/static/js/copyPasteEvents');
+var getCommentIdOnSelection = events.getCommentIdOnSelection;
 
 var cssFiles = ['ep_comments_page/static/css/comment.css', 'ep_comments_page/static/css/commentIcon.css'];
 
@@ -302,7 +304,27 @@ ep_comments.prototype.init = function(){
     self.container.addClass("active");
   }
 
+  // Init copy, cut, paste events
+  if(self.browserIsChrome()){
+    self.padInner.contents().on("copy", function(e) {
+      events.addTextOnClipboard(e, self.ace, self.padInner);
+    });
+
+    self.padInner.contents().on("cut", function(e) {
+      events.addTextOnClipboard(e, self.ace, self.padInner);
+      // remove the selected text
+      self.padInner.contents()[0].execCommand("delete");
+    });
+
+    self.padInner.contents().on("paste", function(e) {
+      events.addCommentClasses(e);
+    });
+  }
 };
+
+ep_comments.prototype.browserIsChrome = function(){
+  return navigator.userAgent.match(/chrome/i)!= null;
+}
 
 // Insert comments container on element use for linenumbers
 ep_comments.prototype.findContainers = function(){
@@ -1162,10 +1184,10 @@ function getRepFromSelector(selector, container){
   });
   return repArr;
 }
-
 // Once ace is initialized, we set ace_doInsertHeading and bind it to the context
 exports.aceInitialized = function(hook, context){
   var editorInfo = context.editorInfo;
   editorInfo.ace_getRepFromSelector = _(getRepFromSelector).bind(context);
+  editorInfo.ace_getCommentIdOnSelection = _(getCommentIdOnSelection).bind(context);
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -17,6 +17,8 @@ var preCommentMark = require('ep_comments_page/static/js/preCommentMark');
 var commentL10n = require('ep_comments_page/static/js/commentL10n');
 var events = require('ep_comments_page/static/js/copyPasteEvents');
 var getCommentIdOnSelection = events.getCommentIdOnSelection;
+var browser = require('ep_etherpad-lite/static/js/browser');
+
 
 var cssFiles = ['ep_comments_page/static/css/comment.css', 'ep_comments_page/static/css/commentIcon.css'];
 
@@ -304,8 +306,14 @@ ep_comments.prototype.init = function(){
     self.container.addClass("active");
   }
 
-  // Init copy, cut, paste events
-  if(self.browserIsChrome()){
+  // Override  copy, cut, paste events on Google chrome.
+  // When an user copies a comment and selects only the span, or part of it, Google chrome
+  // does not copy the classes only the styles, for example:
+  // <comment><span>text to be copied</span></comment>
+  // As the comment classes are not only used for styling we have to add these classes when it pastes the content
+  // The same does not occur when the user selects more than the span, for example:
+  // text<comment><span>to be copied</span></comment>
+  if(browser.chrome){
     self.padInner.contents().on("copy", function(e) {
       events.addTextOnClipboard(e, self.ace, self.padInner);
     });
@@ -321,10 +329,6 @@ ep_comments.prototype.init = function(){
     });
   }
 };
-
-ep_comments.prototype.browserIsChrome = function(){
-  return navigator.userAgent.match(/chrome/i)!= null;
-}
 
 // Insert comments container on element use for linenumbers
 ep_comments.prototype.findContainers = function(){


### PR DESCRIPTION
When an user copies a comment and selects only the span, or part of it, Google chrome
does not copy the classes only the styles, for example in this case:
```
<comment class='comment c-xyz'><span>text to be copied</span></comment>

``` 
Google chrome will copy the styles of the comment class. The result will be something like

```
<comment style="rgb(255, 250, 205)"><span>text to be copied</span></comment>

```

We have to add the comment classes(comment and commentId) otherwise it will lose the comment.


The same does not occur when the user selects more than the span, for example:

```
text<comment class='comment c-xyz'><span>to be copied</span></comment>

```