### PR TITLE
Remove stopImmediatePropagation from listeners

### DIFF
--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -114,15 +114,12 @@ var addListenersToPageView = function() {
 var addListenersToCloseOpenedComment = function() {
   // we need to add listeners to the different iframes of the page
   $(document).on("touchstart click", function(e){
-    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
   getPadOuter().find('html').on("touchstart click", function(e){
-    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
   getPadInner().find('html').on("touchstart click", function(e){
-    e.stopImmediatePropagation(); // to avoid trying to close a comment on both touch and click
     closeOpenedCommentIfNotOnSelectedElements(e);
   });
 }


### PR DESCRIPTION
The stopImmediatePropagation() keeps the rest of the handlers from being
executed. In this case, for example, any another listener which listens 'click' is not handled inside the
padInner. Besides of that, this function does not avoid listening to both
'touchstart' and 'click' as it is written in the comment.

This commit was tested on Moto X android 6, Ipad Mini 2 iOS 9.3.1, Ios Simulator (Iphone 6s Plus iOS 9.3). 